### PR TITLE
Feat/#6 global 설정

### DIFF
--- a/src/main/java/com/req2res/actionarybe/ActionarybeApplication.java
+++ b/src/main/java/com/req2res/actionarybe/ActionarybeApplication.java
@@ -2,7 +2,9 @@ package com.req2res.actionarybe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ActionarybeApplication {
 

--- a/src/main/java/com/req2res/actionarybe/global/Response.java
+++ b/src/main/java/com/req2res/actionarybe/global/Response.java
@@ -1,0 +1,27 @@
+package com.req2res.actionarybe.global;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Getter;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+public class Response<T> {
+	private boolean success;
+	private String message;
+	private T data;
+
+	private Response(boolean success, String message, T data) {
+		this.success = success;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static <T> Response<T> success(String message, T data) {
+		return new Response<>(true, message, data);
+	}
+
+	public static <T> Response<T> fail(String message) {
+		return new Response<>(false, message, null);
+	}
+}

--- a/src/main/java/com/req2res/actionarybe/global/Timestamped.java
+++ b/src/main/java/com/req2res/actionarybe/global/Timestamped.java
@@ -1,0 +1,29 @@
+package com.req2res.actionarybe.global;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class Timestamped {
+
+	@CreatedDate
+	@Column(updatable = false)
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Temporal(TemporalType.TIMESTAMP)
+	private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/req2res/actionarybe/global/exception/CustomException.java
+++ b/src/main/java/com/req2res/actionarybe/global/exception/CustomException.java
@@ -1,0 +1,18 @@
+package com.req2res.actionarybe.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public CustomException(ErrorCode errorCode, String detailMessage) {
+		super(detailMessage);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/req2res/actionarybe/global/exception/ErrorCode.java
+++ b/src/main/java/com/req2res/actionarybe/global/exception/ErrorCode.java
@@ -1,0 +1,30 @@
+package com.req2res.actionarybe.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+	// Basic HttpStatusCode
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD REQUEST"),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN"),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED"),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "NOT FOUND"),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR"),
+
+	// 각 Service에서 필요한 ErrorCode 추가
+
+	//user
+	EMAIL_DUPLICATED(HttpStatus.CONFLICT, "중복된 이메일입니다"),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+}

--- a/src/main/java/com/req2res/actionarybe/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/req2res/actionarybe/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.req2res.actionarybe.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.req2res.actionarybe.global.Response;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	@ExceptionHandler(CustomException.class)
+	protected ResponseEntity<Response<?>> handleDuplicateException(CustomException ex) {
+		ErrorCode errorCode = ex.getErrorCode();
+
+		ex.printStackTrace();
+		return new ResponseEntity<>(Response.fail(errorCode.getMessage()), errorCode.getStatus());
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<Response<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+		String message = ex.getBindingResult().getFieldErrors().stream()
+			.map(FieldError::getDefaultMessage)
+			.findFirst()
+			.orElse("요청값이 올바르지 않습니다.");
+
+		return new ResponseEntity<>(Response.fail(message), HttpStatus.BAD_REQUEST);
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #6 

## 📝작업 내용

### 에러코드 추가

* 추후 ErrorCode Enum에 필요한 에러들을 추가 및 사용하시면 됩니다.

ex) `throw new CustomException(ErrorCode.UNAUTHORIZED);`

---

### response 추가

* Controller 단에서 return할 때 해당 응답을 이용하시면 됩니다.
ex) `return ResponseEntity.ok(Response.success("회원가입 성공", returndto값));`



---

### timestamp 추가

* createdAt || modifiedAt 컬럼이 필요한 엔티티의 경우, 해당 클래스를 상속하면 자동으로 createdAt, modifedAt이 엔티티 및 테이블에 추가, 적용됩니다.

ex) `public class User extends Timestamped`


## 💬리뷰 요구사항(선택)
X
