### PR TITLE
feat:#36 - 회원 탈퇴 로직 구현

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.req2res.actionarybe.domain.auth.controller;
 
+import com.req2res.actionarybe.domain.auth.service.DeleteService;
 import com.req2res.actionarybe.domain.auth.service.LoginService;
 import com.req2res.actionarybe.domain.auth.service.SignupService;
 import com.req2res.actionarybe.domain.member.repository.MemberRepository;
@@ -22,6 +23,7 @@ public class AuthController {
     private final MemberRepository memberRepository;
     private final SignupService signupService;
     private final LoginService loginService;
+    private final DeleteService deleteService;
 
     @PostMapping("/signup")
     public ResponseEntity<Response<SignupResponseDTO>> signup(@Valid @RequestBody SignupRequestDTO req){
@@ -30,10 +32,17 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Response<LoginResponseDTO>> login(
-            @Valid @RequestBody LoginRequestDTO req) {
+    public ResponseEntity<Response<LoginResponseDTO>> login(@Valid @RequestBody LoginRequestDTO req) {
 
         LoginResponseDTO result = loginService.login(req);
         return ResponseEntity.ok(Response.success("로그인에 성공하였습니다.", result));
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Response<Void>> withdraw(@RequestHeader("Authorization") String authHeader){
+        String token=authHeader.substring(7);
+        Long memberId=tokenProvider.getMemberIdFromToken(token);
+        deleteService.withdrawMember(memberId);
+        return ResponseEntity.ok(Response.success("회원 탈퇴에 성공하였습니다.",null));
     }
 }

--- a/src/main/java/com/req2res/actionarybe/domain/auth/service/DeleteService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/service/DeleteService.java
@@ -10,6 +10,9 @@ public class DeleteService {
     public final MemberRepository memberRepository;
 
     public void withdrawMember(Long id){
+        if(!memberRepository.existsById(id)){
+            throw new IllegalArgumentException("해당 ID의 회원이 존재하지 않습니다: " + id);
+        }
         memberRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/req2res/actionarybe/domain/auth/service/DeleteService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/service/DeleteService.java
@@ -1,0 +1,15 @@
+package com.req2res.actionarybe.domain.auth.service;
+
+import com.req2res.actionarybe.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteService {
+    public final MemberRepository memberRepository;
+
+    public void withdrawMember(Long id){
+        memberRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/req2res/actionarybe/domain/auth/service/LoginService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/service/LoginService.java
@@ -25,11 +25,14 @@ public class LoginService {
                 new UsernamePasswordAuthenticationToken(req.getLoginId(), req.getPassword())
         );
 
-        String accessToken = tokenProvider.createToken(req.getLoginId());
-        String refreshToken = tokenProvider.createRefreshToken(req.getLoginId());
-
+        // 1. 로그인 인증 후, DB에서 member 정보 조회
         Member member = memberRepository.findByLoginId(req.getLoginId())
                 .orElseThrow(() -> new BadCredentialsException("Invalid loginId"));
+
+        // 2. JWT 생성 시 memberId와 loginId 모두 포함
+        String accessToken = tokenProvider.createToken(member.getId(), member.getLoginId());
+        String refreshToken = tokenProvider.createRefreshToken(member.getLoginId());
+
 
         return new LoginResponseDTO(
                 member.getId(),

--- a/src/main/java/com/req2res/actionarybe/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/req2res/actionarybe/global/security/JwtTokenProvider.java
@@ -26,11 +26,12 @@ public class JwtTokenProvider {
         this.accessTokenValidityMs = accessMs;
     }
 
-    public String createToken(String loginId) {
+    public String createToken(Long id,String loginId) {
         Date now = new Date();
         Date exp = new Date(now.getTime() + accessTokenValidityMs);
         return Jwts.builder()
                 .setSubject(loginId)
+                .claim("id",id)
                 .setIssuedAt(now)
                 .setExpiration(exp)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
@@ -61,5 +62,14 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token).getBody().getSubject();
         var principal = new User(loginId, "", AuthorityUtils.createAuthorityList("ROLE_USER"));
         return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+    }
+
+    public Long getMemberIdFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("id", Long.class);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#36)

## 📝작업 내용

### 1️⃣ AccessToken에 memberId(id) 정보 추가

기존 AccessToken에는 loginId만 포함되어 있었으나,
이번 작업에서 DB 식별용 PK인 memberId(Long)를 claim으로 추가했습니다.

👉 이제 토큰만으로 현재 사용자 id를 바로 추출할 수 있습니다.

🔹 핵심 포인트
- request body 없는 GET / DELETE 요청에서도 사용자 식별 가능
- 로그인 이후 비즈니스 로직을 loginId가 아닌 id(PK) 기준으로 처리
- 공통으로 재사용 가능한 token → memberId 추출 메서드 제공

🔹 추가된 메서드 **(Token -> id 추출시 사용해주세요)**
위치: global.security.JwtTokenProvider
```
public Long getMemberIdFromToken(String token) {
    return Jwts.parserBuilder()
            .setSigningKey(secretKey)
            .build()
            .parseClaimsJws(token)
            .getBody()
            .get("id", Long.class);
}
```

🔹 사용 예시
```
String token = authHeader.substring(7);
Long memberId = tokenProvider.getMemberIdFromToken(token);
```
→ 프론트는 토큰만 전달
→ 백엔드는 위 메서드로 바로 사용자 id 획득

### 2️⃣ 회원 탈퇴 로직 구현 (물리적 삭제)

JWT에서 추출한 memberId를 기준으로
해당 회원을 DB에서 실제로 삭제하는 탈퇴 기능을 구현했습니다.

🔹 처리 방식
- Soft Delete ❌
- **Hard Delete (물리적 삭제)**
- memberRepository.deleteById(memberId) 사용


## 💬리뷰 요구사항(선택)
**get/delete에서 token -> id 추출 시 getMemberIdFromToken (global.security.JwtTokenProvider에 있음) 사용하셔도 됩니다!**