### PR TITLE
Feat/#62 채팅 관련 API 개발

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/study/controller/StudyParticipantController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/controller/StudyParticipantController.java
@@ -1,5 +1,7 @@
 package com.req2res.actionarybe.domain.study.controller;
 
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +19,7 @@ import com.req2res.actionarybe.domain.study.dto.StudyParticipantNowStateResponse
 import com.req2res.actionarybe.domain.study.dto.StudyParticipantPrivateRequestDto;
 import com.req2res.actionarybe.domain.study.dto.StudyParticipantResponseDto;
 import com.req2res.actionarybe.domain.study.dto.StudyParticipantUsersResponseDto;
+import com.req2res.actionarybe.domain.study.dto.event.ChatMessageRequestEvent;
 import com.req2res.actionarybe.domain.study.service.StudyParticipantService;
 import com.req2res.actionarybe.domain.studyTime.dto.StudyTimeResponseDto;
 import com.req2res.actionarybe.domain.studyTime.dto.StudyTimeTypeRequestDto;
@@ -360,6 +363,16 @@ public class StudyParticipantController {
 		Member member = memberService.findMemberByLoginId(userDetails.getUsername());
 		StudyTimeResponseDto response = studyTimeService.createStudyTimeToDto(member, studyId, request);
 		return Response.success("이전 누적 시간이 저장되고 타이머가 전환되었습니다.", response);
+	}
+
+	@MessageMapping("/studies/{studyId}/chat")
+	public void sendChatMessage(
+		@DestinationVariable Long studyId,
+		ChatMessageRequestEvent request
+	) {
+
+		studyParticipantService.sendChatMessage(studyId, request);
+
 	}
 
 }

--- a/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ChatMessageEvent.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ChatMessageEvent.java
@@ -1,0 +1,21 @@
+package com.req2res.actionarybe.domain.study.dto.event;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageEvent {
+
+	private Long studyParticipantId;
+	private Long studyId;
+	private Long senderId;
+	private String senderNickname;
+	private Long badgeId;
+	private String badgeImageUrl;
+	private String chat;
+	private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ChatMessageRequestEvent.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ChatMessageRequestEvent.java
@@ -1,0 +1,13 @@
+package com.req2res.actionarybe.domain.study.dto.event;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageRequestEvent {
+
+	private Long senderId;
+	private String chat;
+
+}

--- a/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ChatSenderInfo.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ChatSenderInfo.java
@@ -1,0 +1,18 @@
+package com.req2res.actionarybe.domain.study.dto.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChatSenderInfo {
+
+	Long studyParticipantId;
+	Long senderId;
+	String senderNickname;
+	Long badgeId;
+	String badgeImageUrl;
+
+}

--- a/src/main/java/com/req2res/actionarybe/domain/study/dto/event/NowStateChangedEvent.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/dto/event/NowStateChangedEvent.java
@@ -1,12 +1,17 @@
 package com.req2res.actionarybe.domain.study.dto.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class NowStateChangedEvent {
-	private Long studyId;
+
 	private Long studyParticipantId;
+	private Long studyId;
+	private Long userId;
 	private String nowState;
+
 }

--- a/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ParticipantJoinedEvent.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ParticipantJoinedEvent.java
@@ -1,12 +1,20 @@
 package com.req2res.actionarybe.domain.study.dto.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class ParticipantJoinedEvent {
-	private Long studyId;
+
 	private Long studyParticipantId;
+	private Long studyId;
 	private Long userId;
+	private String userNickname;
+	private String profileImageUrl;
+	private Long badgeId;
+	private String badgeImageUrl;
+
 }

--- a/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ParticipantLeftEvent.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/dto/event/ParticipantLeftEvent.java
@@ -1,9 +1,11 @@
 package com.req2res.actionarybe.domain.study.dto.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class ParticipantLeftEvent {
 	private Long studyId;

--- a/src/main/java/com/req2res/actionarybe/domain/study/repository/StudyParticipantRepository.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/repository/StudyParticipantRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import com.req2res.actionarybe.domain.member.entity.Member;
 import com.req2res.actionarybe.domain.study.dto.RankingDurationDto;
 import com.req2res.actionarybe.domain.study.dto.StudyParticipantUserDto;
+import com.req2res.actionarybe.domain.study.dto.event.ChatSenderInfo;
 import com.req2res.actionarybe.domain.study.entity.Study;
 import com.req2res.actionarybe.domain.study.entity.StudyParticipant;
 
@@ -86,6 +87,26 @@ public interface StudyParticipantRepository extends JpaRepository<StudyParticipa
 	List<StudyParticipantUserDto> findParticipantUserByStudyAndIsActiveTrue(Long studyId);
 
 	Optional<StudyParticipant> findByStudyAndMemberAndIsActiveTrue(Study study, Member member);
+
+	@Query("""
+		select new com.req2res.actionarybe.domain.study.dto.event.ChatSenderInfo(
+		    sp.id,
+		    m.id,
+		    m.nickname,
+		    b.id,
+		    b.imageUrl
+		)
+		from StudyParticipant sp
+		join sp.member m
+		join m.badge b
+		where sp.study.id = :studyId
+		  and m.id = :memberId
+		  and sp.isActive = true
+		""")
+	Optional<ChatSenderInfo> findChatSenderInfo(
+		Long studyId,
+		Long memberId
+	);
 
 	// 로그인 유저가 해당 스터디 참여 중인지 (is_active=1)
 	boolean existsByStudy_IdAndMember_IdAndIsActiveTrue(Long studyId, Long memberId);

--- a/src/main/java/com/req2res/actionarybe/domain/study/service/StudyParticipantService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/service/StudyParticipantService.java
@@ -28,7 +28,8 @@ import com.req2res.actionarybe.domain.study.repository.StudyParticipantRepositor
 import com.req2res.actionarybe.domain.study.repository.StudyRepository;
 import com.req2res.actionarybe.domain.studyTime.dto.StudyTimeTypeRequestDto;
 import com.req2res.actionarybe.domain.studyTime.service.StudyTimeService;
-import com.req2res.actionarybe.global.Event;
+import com.req2res.actionarybe.global.event.Event;
+import com.req2res.actionarybe.global.event.EventType;
 import com.req2res.actionarybe.global.exception.CustomException;
 import com.req2res.actionarybe.global.exception.ErrorCode;
 
@@ -74,14 +75,18 @@ public class StudyParticipantService {
 
 		messagingTemplate.convertAndSend(
 			"/topic/studies/" + studyId,
-			new Event<>(
-				"PARTICIPANT_JOINED",
-				new ParticipantJoinedEvent(
-					studyId,
-					studyParticipant.getId(),
-					studyParticipant.getMember().getId()
-				)
-			)
+			Event.builder()
+				.type(EventType.PARTICIPANT_JOINED)
+				.data(ParticipantJoinedEvent.builder()
+					.studyParticipantId(studyParticipant.getId())
+					.studyId(studyId)
+					.userId(member.getId())
+					.userNickname(member.getNickname())
+					.profileImageUrl(member.getProfileImageUrl())
+					.badgeId(member.getBadge().getId())
+					.badgeImageUrl(member.getBadge().getImageUrl())
+					.build())
+				.build()
 		);
 
 		return StudyParticipantResponseDto.from(studyParticipant);
@@ -175,14 +180,15 @@ public class StudyParticipantService {
 
 		messagingTemplate.convertAndSend(
 			"/topic/studies/" + studyId,
-			new Event<>(
-				"NOW_STATE_CHANGED",
-				new NowStateChangedEvent(
-					studyId,
-					studyParticipant.getId(),
-					request.getNowState()
-				)
-			)
+			Event.builder()
+				.type(EventType.NOW_STATE_CHANGED)
+				.data(NowStateChangedEvent.builder()
+					.studyParticipantId(studyParticipant.getId())
+					.studyId(studyId)
+					.userId(member.getId())
+					.nowState(request.getNowState())
+					.build())
+				.build()
 		);
 
 		return StudyParticipantNowStateResponseDto.builder()
@@ -215,13 +221,13 @@ public class StudyParticipantService {
 
 		messagingTemplate.convertAndSend(
 			"/topic/studies/" + studyId,
-			new Event<>(
-				"PARTICIPANT_LEFT",
-				new ParticipantLeftEvent(
-					studyId,
-					studyParticipant.getId()
-				)
-			)
+			Event.builder()
+				.type(EventType.NOW_STATE_CHANGED)
+				.data(ParticipantLeftEvent.builder()
+					.studyId(studyId)
+					.studyParticipantId(studyParticipant.getId())
+					.build())
+				.build()
 		);
 
 	}

--- a/src/main/java/com/req2res/actionarybe/global/event/Event.java
+++ b/src/main/java/com/req2res/actionarybe/global/event/Event.java
@@ -1,11 +1,15 @@
-package com.req2res.actionarybe.global;
+package com.req2res.actionarybe.global.event;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class Event<T> {
-	private String type;
+
+	private EventType type;
 	private T data;
+
 }

--- a/src/main/java/com/req2res/actionarybe/global/event/EventType.java
+++ b/src/main/java/com/req2res/actionarybe/global/event/EventType.java
@@ -7,8 +7,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EventType {
 
+	// 정상응답
 	PARTICIPANT_JOINED,
 	PARTICIPANT_LEFT,
-	NOW_STATE_CHANGED;
+	NOW_STATE_CHANGED,
+	CHAT_MESSAGE,
+
+	// 에러
+	NOT_STUDY_PARTICIPANT;
 
 }

--- a/src/main/java/com/req2res/actionarybe/global/event/EventType.java
+++ b/src/main/java/com/req2res/actionarybe/global/event/EventType.java
@@ -1,0 +1,14 @@
+package com.req2res.actionarybe.global.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+
+	PARTICIPANT_JOINED,
+	PARTICIPANT_LEFT,
+	NOW_STATE_CHANGED;
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #62

## 📝작업 내용

* 기존 STOMP 사용하던 이벤트들의 응답필드 수정

* 채팅 메세지 송/수신 이벤트 구현
    * STOMP 사용 시 HTTP 상태 코드 에러처리 구현은 권장되지 않는 방식이므로 에러 발생 시 이벤트 처리되도록 구현



## 💬리뷰 요구사항(선택)

