### PR TITLE
Docs/#71 api swagger

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/controller/AuthController.java
@@ -5,6 +5,11 @@ import com.req2res.actionarybe.global.Response;
 import com.req2res.actionarybe.domain.auth.dto.*;
 import com.req2res.actionarybe.global.security.CustomUserDetails;
 import com.req2res.actionarybe.global.security.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,21 +24,182 @@ public class AuthController {
     private final JwtTokenProvider tokenProvider;
     private final AuthService authService;
 
-    // 회원가입
+    // ===================== 회원가입 =====================
+    @Operation(summary = "회원가입", description = "회원가입 기능")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원가입 완료",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "회원가입이 완료되었습니다.",
+                      "data": {
+                        "memberId": 1,
+                        "loginId": "newUser123",
+                        "nickname": "새로운유저"
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 입력값이 빠지거나 형식이 틀린 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "입력값이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "중복됨 - 이미 존재하는 사용자",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "이미 존재하는 회원입니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 - 서버 내부 문제",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PostMapping("/signup")
     public ResponseEntity<Response<SignupResponseDTO>> signup(@Valid @RequestBody SignupRequestDTO req){
         SignupResponseDTO result = authService.signup(req);
         return ResponseEntity.ok(Response.success("회원가입에 성공하였습니다.", result));
     }
 
-    // 로그인
+    // ===================== 로그인 (POST) =====================
+    @Operation(summary = "로그인", description = "아이디와 비밀번호로 로그인")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "로그인에 성공하였습니다.",
+                      "data": {
+                        "memberId": 1,
+                        "nickname": "유저1234",
+                        "profileImageUrl": "http://.../default_profile.png",
+                        "accessToken": "eyJhbGciOiJIU...[생성된 JWT]...a5Y",
+                        "refreshToken": "eyJhbGciOiJIU...[생성된 REFRESH JWT]...x8F"
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 입력값이 빠지거나 형식이 틀린 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "아이디 또는 비밀번호 형식이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요 - 토큰이 없거나 유효하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "인증 정보가 유효하지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 - 서버측 문제",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PostMapping("/login")
     public ResponseEntity<Response<LoginResponseDTO>> login(@Valid @RequestBody LoginRequestDTO req) {
         LoginResponseDTO result = authService.login(req);
         return ResponseEntity.ok(Response.success("로그인에 성공하였습니다.", result));
     }
 
-    // 회원 탈퇴
+    // ===================== 회원 탈퇴 (DELETE) =====================
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 회원을 탈퇴 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "회원 탈퇴가 성공적으로 처리되었습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 삭제할 ID가 잘못된 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 정보가 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요 - Authorization 헤더가 없거나 토큰이 유효하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "삭제 금지 - 삭제 권한이 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "삭제 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "찾을 수 없음 - 이미 삭제되었거나 존재하지 않는 회원",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 회원을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 - 삭제 중 서버 내부 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @DeleteMapping("/withdraw")
     public ResponseEntity<Response<Void>> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails){
         Long id = userDetails.getId();
@@ -41,7 +207,63 @@ public class AuthController {
         return ResponseEntity.ok(Response.success("회원 탈퇴에 성공하였습니다.",null));
     }
 
-    // 로그인 유지 (refreshToken 활용)
+    // ===================== 로그인 유지 / 토큰 재발급 (POST) =====================
+    @Operation(summary = "Access Token 재발급", description = "Refresh Token을 이용하여 Access Token을 재발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Access Token 재발급 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "AccessToken 재발급 완료",
+                      "data": {
+                        "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzNCIsImlhdCI6MTc2Njg1MzIwNiwiZXhwIjoxNzY2ODU2ODA2fQ.Ud6cfSMOZbTyT7Cg-OZq8VlcKCzPDzz8jTzs2UUxrBQ"
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 입력값이 빠지거나 형식이 틀린 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 값이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요 - Authorization 헤더가 없거나 토큰이 유효하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "Refresh Token이 유효하지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 - 토큰 재발급 권한이 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "토큰 재발급 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 - 서버 내부 문제",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PostMapping("/refresh")
     public ResponseEntity<Response<RefreshTokenResponseDTO>> refreshAccessToken(
             @RequestBody @Valid RefreshTokenRequestDTO request

--- a/src/main/java/com/req2res/actionarybe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/comment/controller/CommentController.java
@@ -4,12 +4,16 @@ import com.req2res.actionarybe.domain.comment.dto.*;
 import com.req2res.actionarybe.domain.comment.service.CommentService;
 import com.req2res.actionarybe.global.Response;
 import com.req2res.actionarybe.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,21 +24,161 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    // 댓글 생성
+    // ===================== 댓글 생성 (POST) =====================
+    @Operation(summary = "댓글 생성", description = "특정 게시글에 댓글을 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 생성 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "댓글이 성공적으로 등록되었습니다.",
+                      "data": {
+                        "commentId": 1,
+                        "content": "좋은 질문입니다.",
+                        "isSecret": false,
+                        "createdAt": "2023-10-27T11:00:00",
+                        "author": {
+                          "memberId": 2,
+                          "nickname": "개발자B"
+                        }
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 입력값이 빠지거나 형식이 틀린 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 값이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요 - 토큰이 없거나 유효하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 - 댓글 작성 권한이 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "댓글 작성 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PostMapping("/{postId}/comments")
-    public ResponseEntity<?> createComment(
+    public Response<CommentResponseDTO> createComment(
             @PathVariable("postId") Long postId,
             @RequestBody CreateCommentRequestDTO response,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long memberId=userDetails.getId();
+        Long memberId = userDetails.getId();
         CommentResponseDTO result = commentService.createComment(postId, response, memberId);
-        return ResponseEntity.ok(Response.success("댓글 생성 성공", result));
+        return Response.success("댓글 생성 성공", result);
     }
 
-    // 최신순 정렬된 댓글 조회
+    // ===================== 댓글 조회 (GET - 최신순) =====================
+    @Operation(summary = "댓글 조회", description = "특정 게시글의 댓글을 최신순으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "댓글이 성공적으로 조회되었습니다.",
+                      "data": {
+                        "comments": [
+                          {
+                            "commentId": 1,
+                            "content": "좋은 질문입니다.",
+                            "createdAt": "2023-10-27T11:00:00",
+                            "isSecret": false,
+                            "author": {
+                              "memberId": 2,
+                              "nickname": "개발자B",
+                              "profileImageUrl": "https://.../userB.png",
+                              "badgeId": 1
+                            }
+                          },
+                          {
+                            "commentId": 2,
+                            "content": "저도 궁금했어요!",
+                            "createdAt": "2023-10-27T12:00:00",
+                            "isSecret": false,
+                            "author": {
+                              "memberId": 3,
+                              "nickname": "개발자C",
+                              "profileImageUrl": "https://.../userC.png",
+                              "badgeId": 2
+                            }
+                          }
+                        ],
+                        "pageInfo": {
+                          "page": 0,
+                          "size": 10,
+                          "totalElements": 25,
+                          "totalPages": 3
+                        }
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 페이지 파라미터 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 형식이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "찾을 수 없음 - 게시글 또는 댓글이 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "댓글을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @GetMapping("/{postId}/comments")
-    public ResponseEntity<Response<GetCommentResponseDTO>> getLatestPosts(
+    public Response<GetCommentResponseDTO> getLatestPosts(
             @RequestParam(defaultValue = "0", required = false) int page,
             @PathVariable("postId") Long postId
     ) {
@@ -45,25 +189,164 @@ public class CommentController {
         );
 
         GetCommentResponseDTO result = commentService.getCommentsByPostId(postId, pageable);
-        return ResponseEntity.ok(Response.success("특정 게시글의 댓글 조회 성공", result));
+        return Response.success("특정 게시글의 댓글 조회 성공", result);
     }
 
-    // 댓글 수정
+    // ===================== 댓글 수정 (PATCH) =====================
+    @Operation(summary = "댓글 수정", description = "댓글 내용을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "게시글 댓글 수정 성공",
+                      "data": {
+                        "commentId": 1,
+                        "content": "수정된 댓글 내용입니다.",
+                        "isSecret": true,
+                        "createdAt": "2023-10-27T11:00:00",
+                        "author": {
+                          "memberId": 2,
+                          "nickname": "개발자B"
+                        }
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 수정할 내용이 올바르지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 값이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "수정 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "수정 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "찾을 수 없음 - 댓글이 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 댓글을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PatchMapping("/comments/{commentId}")
-    public ResponseEntity<Response<CommentResponseDTO>> updateComment(
-        @PathVariable("commentId") Long commentId,
-        @Valid@RequestBody UpdateCommentRequestDTO request
+    public Response<CommentResponseDTO> updateComment(
+            @PathVariable("commentId") Long commentId,
+            @Valid @RequestBody UpdateCommentRequestDTO request
     ){
         CommentResponseDTO result = commentService.updateComment(commentId, request);
-        return ResponseEntity.ok(Response.success("게시글 댓글 수정 성공", result));
+        return Response.success("게시글 댓글 수정 성공", result);
     }
 
-    // 댓글 삭제
+    // ===================== 댓글 삭제 (DELETE) =====================
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 삭제 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "게시글 댓글 삭제 성공",
+                      "data": {
+                        "commentId": 2
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 삭제할 ID가 잘못된 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 정보가 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "삭제 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "삭제 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "찾을 수 없음 - 댓글이 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 댓글을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity<Response<DeleteCommentResponseDTO>> deleteComment(
+    public Response<DeleteCommentResponseDTO> deleteComment(
             @PathVariable("commentId") Long commentId
     ){
-        DeleteCommentResponseDTO result=commentService.deleteComment(commentId);
-        return ResponseEntity.ok(Response.success("게시글 댓글 삭제 성공", result));
+        DeleteCommentResponseDTO result = commentService.deleteComment(commentId);
+        return Response.success("게시글 댓글 삭제 성공", result);
     }
 }

--- a/src/main/java/com/req2res/actionarybe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/member/controller/MemberController.java
@@ -4,10 +4,14 @@ import com.req2res.actionarybe.domain.member.dto.*;
 import com.req2res.actionarybe.domain.member.service.MemberService;
 import com.req2res.actionarybe.global.Response;
 import com.req2res.actionarybe.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,47 +22,393 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    // 로그인 유저 정보 조회
-    @GetMapping("/me/info")
+    // ===================== 로그인 유저 정보 조회 (GET) =====================
+    @Operation(summary = "로그인 유저 정보 조회", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @SecurityRequirement(name = "Bearer Token")
-    public ResponseEntity<Response<LoginMemberResponseDTO>> meInfo(
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "사용자 정보 조회가 완료되었습니다.",
+                      "data": {
+                        "memberId": 1,
+                        "profileImageUrl": "https://example.com/images/default.png",
+                        "nickname": "솔룩스123",
+                        "phoneNumber": "010-1234-5678",
+                        "birthday": "1995-10-25"
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 형식이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "접근 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "접근 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 정보 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 회원을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
+    @GetMapping("/me/info")
+    public Response<LoginMemberResponseDTO> meInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long id = userDetails.getId();
         LoginMemberResponseDTO result = memberService.getLoginMemberInfo(id);
-        return ResponseEntity.ok(Response.success("로그인 유저 정보 조회 성공", result));
+        return Response.success("로그인 유저 정보 조회 성공", result);
     }
 
-    // 프로필 사진 수정
+    // ===================== 타인 정보 조회 (GET) =====================
+    @Operation(summary = "타인 정보 조회", description = "회원 ID를 통해 다른 사용자의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "타인정보 조회 성공",
+                      "data": {
+                        "memberId": 2,
+                        "nickname": "other nickname",
+                        "profileImageUrl": "https://example.com/images/other.png"
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 형식이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "접근 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "접근 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 정보 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 회원을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
+    @GetMapping("/{memberId}")
+    public Response<OtherMemberResponseDTO> memberInfo(
+            @PathVariable("memberId") Long memberId
+    ){
+        OtherMemberResponseDTO result=memberService.getOtherMemberInfo(memberId);
+        return Response.success("타인정보 조회 성공",result);
+    }
+
+    // ===================== 프로필 사진 수정 (PATCH) =====================
+    @Operation(summary = "프로필 사진 수정", description = "로그인한 사용자의 프로필 사진을 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "프로필 변경 성공"
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 값이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "수정 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "수정 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 정보 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 회원을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PatchMapping("me/profile")
-    public ResponseEntity<Response<UpdateProfileRequestDTO>> profile(
+    public Response<UpdateProfileRequestDTO> profile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UpdateProfileRequestDTO updateProfileRequestDTO
     ) {
         Long id=userDetails.getId();
         memberService.updateProfile(id,updateProfileRequestDTO.getImageUrl());
-        return ResponseEntity.ok(Response.success("프로필 사진 변경에 성공했습니다.",null));
+        return Response.success("프로필 사진 변경에 성공했습니다.",null);
     }
 
-    // 닉네임 수정
+    // ===================== 닉네임 수정 (PATCH) =====================
+    @Operation(summary = "닉네임 수정", description = "로그인한 사용자의 닉네임을 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "닉네임이 성공적으로 변경되었습니다.",
+                      "data": {
+                        "memberId": 123,
+                        "nickname": "새로운닉네임"
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 값이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "수정 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "수정 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 정보 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 회원을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PatchMapping("me/nickname")
-    public ResponseEntity<Response<UpdateNicknameResponseDTO>> nickname(
+    public Response<UpdateNicknameResponseDTO> nickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UpdateNicknameRequestDTO updateNickNameRequestDTO
     ){
         Long id = userDetails.getId();
         String nickname=updateNickNameRequestDTO.getNickname();
         UpdateNicknameResponseDTO result=memberService.updateNickname(id,nickname);
-        return ResponseEntity.ok(Response.success("닉네임 변경에 성공했습니다.",result));
+        return Response.success("닉네임 변경에 성공했습니다.",result);
     }
 
-    // 뱃지 조회
+    // ===================== 뱃지 조회 (GET) =====================
+    @Operation(summary = "뱃지 조회", description = "로그인한 사용자의 뱃지 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "뱃지 조회에 성공했습니다.",
+                      "result": {
+                        "badgeId": 2,
+                        "badgeName": "10p",
+                        "requiredPoint": 10,
+                        "badgeImageUrl": "https://.../images/badge_level_1.png"
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 형식이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "접근 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "접근 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "뱃지 정보 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "뱃지 정보를 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @GetMapping("me/badge")
-    public ResponseEntity<Response<BadgeResponseDTO>> badge(
+    public Response<BadgeResponseDTO> badge(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ){
         Long id=userDetails.getId();
         BadgeResponseDTO result = memberService.badge(id);
-        return ResponseEntity.ok(Response.success("뱃지 정보 조회에 성공했습니다.",result));
+        return Response.success("뱃지 정보 조회에 성공했습니다.",result);
     }
 }

--- a/src/main/java/com/req2res/actionarybe/domain/member/dto/OtherMemberResponseDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/member/dto/OtherMemberResponseDTO.java
@@ -1,0 +1,12 @@
+package com.req2res.actionarybe.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OtherMemberResponseDTO {
+    private Long memberId;
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/req2res/actionarybe/domain/member/service/MemberService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/member/service/MemberService.java
@@ -38,6 +38,17 @@ public class MemberService {
         );
     }
 
+    // 타인정보 조회
+    public OtherMemberResponseDTO getOtherMemberInfo(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        return new OtherMemberResponseDTO(
+                member.getId(),
+                member.getNickname(),
+                member.getProfileImageUrl()
+        );
+    }
+
     // 프로필 사진 변경
     @Transactional
     public UpdateProfileRequestDTO updateProfile(Long id, String imageUrl){

--- a/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
@@ -96,13 +96,13 @@ public class PostController {
             )
     })
     @PostMapping("")
-    public ResponseEntity<Response<CreatePostResponseDTO>> createPost(
+    public Response<CreatePostResponseDTO> createPost(
             @Valid @RequestBody CreatePostRequestDTO createPostRequestDTO,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ){
         Long member_id = userDetails.getId();
         CreatePostResponseDTO result = postService.createPost(createPostRequestDTO, member_id);
-        return ResponseEntity.ok(Response.success("게시글 생성 성공",result));
+        return Response.success("게시글 생성 성공",result);
     }
 
     // ===================== 게시글 상세 조회 (GET) =====================
@@ -170,11 +170,11 @@ public class PostController {
             )
     })
     @GetMapping("/{post_id}")
-    public ResponseEntity<Response<GetPostResponseDTO>> getPostById(
+    public Response<GetPostResponseDTO> getPostById(
             @PathVariable("post_id") Long postId
     ){
         GetPostResponseDTO result = postService.getPost(postId);
-        return ResponseEntity.ok(Response.success("post_id에 따른 게시글 조회 성공", result));
+        return Response.success("post_id에 따른 게시글 조회 성공", result);
     }
 
     // ===================== 게시글 수정 (PATCH) =====================
@@ -242,7 +242,7 @@ public class PostController {
             )
     })
     @PatchMapping("/{post_id}")
-    public ResponseEntity<Response<UpdatePostResponseDTO>> updatePost(
+    public Response<UpdatePostResponseDTO> updatePost(
             @PathVariable("post_id") Long postId,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "게시글 수정 요청 예시 (전체 수정 / 일부 수정)",
@@ -277,7 +277,7 @@ public class PostController {
             @Valid @RequestBody UpdatePostRequestDTO request
     ){
         UpdatePostResponseDTO result = postService.updatePost(postId, request);
-        return ResponseEntity.ok(Response.success("게시글 수정 성공", result));
+        return Response.success("게시글 수정 성공", result);
     }
 
     // ===================== 게시글 삭제 (DELETE) =====================
@@ -348,11 +348,11 @@ public class PostController {
             )
     })
     @DeleteMapping("/{post_id}")
-    public ResponseEntity<Response<DeletePostResponseDTO>> deletePost(
+    public Response<DeletePostResponseDTO> deletePost(
             @PathVariable("post_id") Long postId
     ){
         DeletePostResponseDTO result = postService.deletePost(postId);
-        return ResponseEntity.ok(Response.success("게시글 삭제 성공", result));
+        return Response.success("게시글 삭제 성공", result);
     }
 
     // ===================== 최신순 게시글 조회 (GET) =====================
@@ -408,7 +408,7 @@ public class PostController {
             )
     })
     @GetMapping("/latest")
-    public ResponseEntity<Response<SortedResponseDTO>> getLatestPosts(
+    public Response<SortedResponseDTO> getLatestPosts(
             @RequestParam(defaultValue = "0", required = false) int page,
             @RequestParam(required = false) Post.Type type
     ) {
@@ -420,9 +420,7 @@ public class PostController {
 
         SortedResponseDTO result = postService.getSortedPosts(type, pageable);
 
-        return ResponseEntity.ok(
-                Response.success("최신순 게시글 조회를 성공했습니다.", result)
-        );
+        return Response.success("최신순 게시글 조회를 성공했습니다.", result);
     }
 
     // ===================== 인기순 게시글 조회 (GET) =====================
@@ -478,7 +476,7 @@ public class PostController {
             )
     })
     @GetMapping("/popular")
-    public ResponseEntity<Response<SortedResponseDTO>> getPopularPosts(
+    public Response<SortedResponseDTO> getPopularPosts(
             @RequestParam(defaultValue = "0", required = false) int page,
             @RequestParam(required = false) Post.Type type
     ) {
@@ -490,8 +488,6 @@ public class PostController {
 
         SortedResponseDTO result = postService.getSortedPosts(type, pageable);
 
-        return ResponseEntity.ok(
-                Response.success("인기순 게시글 조회를 성공했습니다.", result)
-        );
+        return Response.success("인기순 게시글 조회를 성공했습니다.", result);
     }
 }

--- a/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
@@ -5,12 +5,16 @@ import com.req2res.actionarybe.domain.post.entity.Post;
 import com.req2res.actionarybe.domain.post.service.PostService;
 import com.req2res.actionarybe.global.Response;
 import com.req2res.actionarybe.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,9 +22,79 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("api/posts")
 public class PostController {
+
     private final PostService postService;
 
-    // 게시글 생성
+    // ===================== 게시글 생성 (POST) =====================
+    @Operation(summary = "게시글 생성", description = "게시글을 새로 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 생성 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "게시글이 성공적으로 생성됨.",
+                      "data": {
+                        "postId": 108,
+                        "title": "오늘의 스터디",
+                        "nickname": "닉네임1234",
+                        "createdAt": "2025-01-11T08:10:20"
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 입력값이 빠지거나 형식이 틀린 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 값이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요 - Authorization 헤더가 없거나 토큰이 유효하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 - 게시글 생성 권한이 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "게시글 생성 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "중복됨 - 이미 존재하는 게시글",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "이미 존재하는 게시글입니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류 - 서버 내부 문제",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PostMapping("")
     public ResponseEntity<Response<CreatePostResponseDTO>> createPost(
             @Valid @RequestBody CreatePostRequestDTO createPostRequestDTO,
@@ -31,7 +105,70 @@ public class PostController {
         return ResponseEntity.ok(Response.success("게시글 생성 성공",result));
     }
 
-    // 게시글 조회 (post_id에 따른)
+    // ===================== 게시글 상세 조회 (GET) =====================
+    @Operation(summary = "게시글 상세 조회", description = "post_id로 게시글 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 상세 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "게시글 상세 조회에 성공했습니다.",
+                      "data": {
+                        "post": {
+                          "postId": 101,
+                          "type": "질문",
+                          "title": "ERD 설계 질문입니다",
+                          "textContent": "게시글 본문 내용... 텍스트입니다.",
+                          "commentCount": 2,
+                          "createdAt": "2023-10-27T10:00:00"
+                        },
+                        "postImageUrls": [
+                          "https://storage.com/aaa.jpg",
+                          "https://storage.com/bbb.jpg"
+                        ],
+                        "author": {
+                          "memberId": 1,
+                          "nickname": "개발자A",
+                          "profileImageUrl": "https://.../default.png",
+                          "badge": 0
+                        }
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - ID 형식이 잘못된 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 형식이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "찾을 수 없음 - 게시글이 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 게시글을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @GetMapping("/{post_id}")
     public ResponseEntity<Response<GetPostResponseDTO>> getPostById(
             @PathVariable("post_id") Long postId
@@ -40,17 +177,176 @@ public class PostController {
         return ResponseEntity.ok(Response.success("post_id에 따른 게시글 조회 성공", result));
     }
 
-    // 게시글 수정
+    // ===================== 게시글 수정 (PATCH) =====================
+    @Operation(summary = "게시글 수정", description = "게시글을 수정합니다. 수정된 필드만 보내도 됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "게시글 수정 성공"
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 수정할 내용이 올바르지 않을 때",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 값이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "수정 금지 - 수정 권한이 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "수정 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "찾을 수 없음 - 수정하려는 게시글이 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 게시글을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @PatchMapping("/{post_id}")
     public ResponseEntity<Response<UpdatePostResponseDTO>> updatePost(
             @PathVariable("post_id") Long postId,
-            @Valid@RequestBody UpdatePostRequestDTO request
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "게시글 수정 요청 예시 (전체 수정 / 일부 수정)",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(
+                                    name = "전체 수정",
+                                    value = """
+                                    {
+                                      "type": "인증",
+                                      "title": "수정된 스터디1",
+                                      "text": "ERD 설계는 정말 중요합니다.",
+                                      "imageUrls": [
+                                        "https://storage.com/ccc.jpg",
+                                        "https://storage.com/ddd.jpg"
+                                      ]
+                                    }
+                                    """
+                            ),
+                            @ExampleObject(
+                                    name = "일부 수정",
+                                    value = """
+                                    {
+                                      "title": "수정된 스터디2",
+                                      "imageUrls": [
+                                        "https://storage.com/ddd.jpg"
+                                      ]
+                                    }
+                                    """
+                            )
+                    })
+            )
+            @Valid @RequestBody UpdatePostRequestDTO request
     ){
         UpdatePostResponseDTO result = postService.updatePost(postId, request);
         return ResponseEntity.ok(Response.success("게시글 수정 성공", result));
     }
 
-    // 게시글 삭제
+    // ===================== 게시글 삭제 (DELETE) =====================
+    @Operation(summary = "게시글 삭제", description = "post_id로 게시글을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 삭제 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "게시글이 성공적으로 삭제되었습니다.",
+                      "data": {
+                        "postId": 108
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 삭제할 ID가 잘못된 경우",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 정보가 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 필요",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "로그인이 필요합니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "삭제 금지 - 삭제 권한이 없음",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "삭제 권한이 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "찾을 수 없음 - 이미 삭제되었거나 존재하지 않는 게시글",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "해당 게시글을 찾을 수 없습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @DeleteMapping("/{post_id}")
     public ResponseEntity<Response<DeletePostResponseDTO>> deletePost(
             @PathVariable("post_id") Long postId
@@ -59,7 +355,58 @@ public class PostController {
         return ResponseEntity.ok(Response.success("게시글 삭제 성공", result));
     }
 
-    // 최신순 정렬된 게시글 조회
+    // ===================== 최신순 게시글 조회 (GET) =====================
+    @Operation(summary = "최신순 게시글 조회", description = "게시글을 최신순으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "게시글 목록 조회에 성공했습니다.",
+                      "data": {
+                        "posts": [
+                          {
+                            "postId": 101,
+                            "type": "소통",
+                            "title": "ERD 설계 질문입니다",
+                            "nickname": "개발자A",
+                            "createdAt": "2023-10-27T10:00:00",
+                            "commentCount": 2
+                          }
+                        ],
+                        "pageInfo": {
+                          "page": 0,
+                          "size": 10,
+                          "totalElements": 150,
+                          "totalPages": 8
+                        }
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 페이지 파라미터 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 형식이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @GetMapping("/latest")
     public ResponseEntity<Response<SortedResponseDTO>> getLatestPosts(
             @RequestParam(defaultValue = "0", required = false) int page,
@@ -78,7 +425,58 @@ public class PostController {
         );
     }
 
-    // 인기순(댓글 개수) 정렬된 게시글 조회
+    // ===================== 인기순 게시글 조회 (GET) =====================
+    @Operation(summary = "인기순 게시글 조회", description = "게시글을 댓글 개수 기준 인기순으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": true,
+                      "message": "게시글 목록 조회에 성공했습니다.",
+                      "data": {
+                        "posts": [
+                          {
+                            "postId": 100,
+                            "type": "소통",
+                            "title": "API 명세서 질문",
+                            "nickname": "개발자B",
+                            "createdAt": "2023-10-26T15:00:00",
+                            "commentCount": 5
+                          }
+                        ],
+                        "pageInfo": {
+                          "page": 0,
+                          "size": 10,
+                          "totalElements": 150,
+                          "totalPages": 8
+                        }
+                      }
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 - 페이지 파라미터 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "요청 형식이 올바르지 않습니다."
+                    }
+                    """))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                    {
+                      "success": false,
+                      "message": "서버 오류가 발생했습니다."
+                    }
+                    """))
+            )
+    })
     @GetMapping("/popular")
     public ResponseEntity<Response<SortedResponseDTO>> getPopularPosts(
             @RequestParam(defaultValue = "0", required = false) int page,


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#71 )

## 📝작업 내용
- controller에 Swagger 주석 및 설명 추가 (Auth(인증), Member(개인정보 수정/조회), Post(게시글), Comment(게시글 댓글))
- other member PR 코드 작업 누락된 부분 보완 (Member에 '타인 정보 조회' controller, service, dto 날아갔었음)
https://github.com/Solux-2025-2-TeamReq2Res/BackEnd/pull/70 


## 💬리뷰 요구사항(선택)
없음