### PR TITLE
Fix/#77 refresh token

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/controller/AuthController.java
@@ -279,7 +279,7 @@ public class AuthController {
         String loginId = tokenProvider.getLoginIdFromToken(refreshToken);
 
         // 새 access token 생성
-        String newAccessToken = tokenProvider.createToken(null, loginId); // id 없이 생성
+        String newAccessToken = tokenProvider.createAccessToken(null, loginId); // id 없이 생성
 
         return ResponseEntity.ok(Response.success("AccessToken 재발급 완료",
                 new RefreshTokenResponseDTO(newAccessToken)));

--- a/src/main/java/com/req2res/actionarybe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/controller/AuthController.java
@@ -268,20 +268,7 @@ public class AuthController {
     public ResponseEntity<Response<RefreshTokenResponseDTO>> refreshAccessToken(
             @RequestBody @Valid RefreshTokenRequestDTO request
     ) {
-        String refreshToken = request.getRefreshToken();
-
-        // Refresh Token 유효성 검사
-        if (!tokenProvider.validate(refreshToken)) {
-            return ResponseEntity.badRequest().body(Response.fail("Refresh Token이 유효하지 않습니다."));
-        }
-
-        // loginId 추출
-        String loginId = tokenProvider.getLoginIdFromToken(refreshToken);
-
-        // 새 access token 생성
-        String newAccessToken = tokenProvider.createAccessToken(null, loginId); // id 없이 생성
-
-        return ResponseEntity.ok(Response.success("AccessToken 재발급 완료",
-                new RefreshTokenResponseDTO(newAccessToken)));
+        RefreshTokenResponseDTO result = authService.refreshToken(request);
+        return ResponseEntity.ok(Response.success("accessToken 발급 성공",result));
     }
 }

--- a/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
@@ -66,7 +66,7 @@ public class AuthService {
         }
 
         // 3. JWT 생성 시 memberId와 loginId 모두 포함
-        String accessToken = tokenProvider.createToken(member.getId(), member.getLoginId());
+        String accessToken = tokenProvider.createAccessToken(member.getId(), member.getLoginId());
         String refreshToken = tokenProvider.createRefreshToken(member.getLoginId());
 
         return new LoginResponseDTO(

--- a/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
@@ -1,18 +1,17 @@
 package com.req2res.actionarybe.domain.auth.service;
 
-import com.req2res.actionarybe.domain.auth.dto.LoginRequestDTO;
-import com.req2res.actionarybe.domain.auth.dto.LoginResponseDTO;
-import com.req2res.actionarybe.domain.auth.dto.SignupRequestDTO;
-import com.req2res.actionarybe.domain.auth.dto.SignupResponseDTO;
+import com.req2res.actionarybe.domain.auth.dto.*;
 import com.req2res.actionarybe.domain.member.entity.Badge;
 import com.req2res.actionarybe.domain.member.entity.Member;
 import com.req2res.actionarybe.domain.member.repository.BadgeRepository;
 import com.req2res.actionarybe.domain.member.repository.MemberRepository;
+import com.req2res.actionarybe.global.Response;
 import com.req2res.actionarybe.global.exception.CustomException;
 import com.req2res.actionarybe.global.exception.ErrorCode;
 import com.req2res.actionarybe.global.security.JwtTokenProvider;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -66,7 +65,7 @@ public class AuthService {
         }
 
         // 3. JWT 생성 시 memberId와 loginId 모두 포함
-        String accessToken = tokenProvider.createAccessToken(member.getId(), member.getLoginId());
+        String accessToken = tokenProvider.createAccessToken(member.getLoginId());
         String refreshToken = tokenProvider.createRefreshToken(member.getLoginId());
 
         return new LoginResponseDTO(
@@ -115,5 +114,26 @@ public class AuthService {
         // 5. 결과 반환 (Entity -> DTO 변환)
         // 아까 배운 from 메서드 활용!
         return SignupResponseDTO.from(savedMember);
+    }
+
+    // RefreshToken 발급
+    public RefreshTokenResponseDTO refreshToken(RefreshTokenRequestDTO request) {
+        String refreshToken = request.getRefreshToken();
+
+        // RefreshToken 맞는지, AccessToken은 아닌지 검사
+        if (!tokenProvider.isRefreshToken(refreshToken)) {
+            throw new CustomException(ErrorCode.NOT_REFRESHTOKEN);
+        }
+
+        // RefreshToken 유효성 검사
+        if (!tokenProvider.validate(refreshToken)) {
+            throw new CustomException(ErrorCode.INVALID_REFRESHTOKEN);
+        }
+
+        // loginId로 AccessToken 생성
+        String loginId = tokenProvider.getLoginIdFromToken(refreshToken);
+        String newAccessToken = tokenProvider.createAccessToken(loginId); // memberId: 나중에 loginId로 DB 조회해서 가져옴
+
+        return new RefreshTokenResponseDTO(newAccessToken);
     }
 }

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/PostContentRequestDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/PostContentRequestDTO.java
@@ -14,7 +14,7 @@ public class PostContentRequestDTO {
 
     @Schema(
             description = "게시글 본문 내용",
-            example = "자료구조 스터디 완료"
+            example = "자료구조 스터디\n완료"
     )
     @NotBlank
     private String text;

--- a/src/main/java/com/req2res/actionarybe/global/config/SecurityConfig.java
+++ b/src/main/java/com/req2res/actionarybe/global/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/ws/**")
 				.permitAll()
-				.requestMatchers("/api/auth/login", "/api/auth/signup",
+				.requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/refresh",
 					"/swagger", "/swagger-ui.html", "/swagger-ui/**",
 					"/api-docs", "/api-docs/**", "/v3/api-docs/**")
 				.permitAll()

--- a/src/main/java/com/req2res/actionarybe/global/exception/ErrorCode.java
+++ b/src/main/java/com/req2res/actionarybe/global/exception/ErrorCode.java
@@ -73,6 +73,8 @@ public enum ErrorCode {
 	INVALID_FIELD_TYPE(HttpStatus.BAD_REQUEST, "JSON 필드 타입이 올바르지 않습니다"),
 
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+	INVALID_REFRESHTOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 refreshToken입니다."),
+	NOT_REFRESHTOKEN(HttpStatus.BAD_REQUEST, "refreshToken이 아닙니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
 	MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
 

--- a/src/main/java/com/req2res/actionarybe/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/req2res/actionarybe/global/security/JwtTokenProvider.java
@@ -29,7 +29,7 @@ public class JwtTokenProvider {
         this.accessTokenValidityMs = accessMs;
     }
 
-    public String createToken(Long id,String loginId) {
+    public String createAccessToken(Long id, String loginId) {
         Date now = new Date();
         Date exp = new Date(now.getTime() + accessTokenValidityMs);
         return Jwts.builder()

--- a/src/main/java/com/req2res/actionarybe/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/req2res/actionarybe/global/security/JwtTokenProvider.java
@@ -29,34 +29,48 @@ public class JwtTokenProvider {
         this.accessTokenValidityMs = accessMs;
     }
 
-    public String createAccessToken(Long id, String loginId) {
+    public String createAccessToken(String loginId) {
         Date now = new Date();
         Date exp = new Date(now.getTime() + accessTokenValidityMs);
         return Jwts.builder()
                 .setSubject(loginId)
+                .claim("type", "access")         // 토큰 타입
                 .setIssuedAt(now)
                 .setExpiration(exp)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    public String createRefreshToken(String loginId) {
+    public String createRefreshToken(String loginId) { // memberId: 나중에 loginId로 DB 조회해서 가져옴
         final long refreshTokenValidityMs = 1209600000; // 2주
         Date now = new Date();
         Date exp = new Date(now.getTime() + refreshTokenValidityMs);
         return Jwts.builder()
                 .setSubject(loginId)
+                .claim("type", "refresh")        // Access Token과 구분
                 .setIssuedAt(now)
                 .setExpiration(exp)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public boolean isRefreshToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return "refresh".equals(claims.get("type"));
     }
 
     public boolean validate(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
             return true;
-        } catch (JwtException | IllegalArgumentException e) { return false; }
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
     }
 
     public Authentication getAuthentication(String token) {

--- a/src/test/http/auth/loginTest.http
+++ b/src/test/http/auth/loginTest.http
@@ -8,4 +8,5 @@ Content-Type: application/json
 
 > {%
     client.global.set("accessToken", "Bearer " + response.body.data.accessToken);
+    client.global.set("refreshToken", response.body.data.refreshToken);
 %}

--- a/src/test/http/auth/logout.http
+++ b/src/test/http/auth/logout.http
@@ -1,5 +1,3 @@
-@access_token = 여기에 토큰
-
 ### 회원 탈퇴
 DELETE http://localhost:8080/api/auth/withdraw
 Authorization: {{accessToken}}

--- a/src/test/http/auth/refreshToken.http
+++ b/src/test/http/auth/refreshToken.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/api/auth/refresh
+Content-Type: application/json
+
+{
+  "refreshToken": "{{refreshToken}}"
+}
+
+> {%
+    client.global.set("accessToken", "Bearer " + response.body.data.accessToken);
+%}

--- a/src/test/http/post/postCreate.http
+++ b/src/test/http/post/postCreate.http
@@ -1,5 +1,3 @@
-@access_token = 여기에 입력
-
 ### 게시글 생성1
 POST http://localhost:8080/api/posts
 Authorization: {{accessToken}}

--- a/src/test/http/post/postUpdate.http
+++ b/src/test/http/post/postUpdate.http
@@ -1,5 +1,3 @@
-@access_token = 여기에 입력
-
 ### 게시글 생성
 POST http://localhost:8080/api/posts
 Authorization: {{accessToken}}


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#77 )

## 📝작업 내용
### 1️⃣ /api/auth/refresh 접근 허용
- SecurityConfig의 .authorizeHttpRequests에 **/api/auth/refresh 경로를 추가**함
- **AccessToken이 만료된 상황**에서도 **RefreshToken으로 재발급이 가능하도록** 하기 위함
- 즉, refresh API는 AccessToken 검증 없이 접근 가능하도록 설정

### 2️⃣ AccessToken / RefreshToken 구분용 Claim 추가
- **두 토큰**을 명확히 **구분**하기 위해 **type 클레임을 추가**함
   - AccessToken → **.claim("type", "access")**
   - RefreshToken → **.claim("type", "refresh")**
- 토큰 용도를 명시적으로 구분하여 잘못된 토큰 사용을 방지

### 3️⃣ RefreshToken 여부 검증 메서드 추가
```
public boolean isRefreshToken(String token) {
    Claims claims = Jwts.parserBuilder()
            .setSigningKey(secretKey)
            .build()
            .parseClaimsJws(token)
            .getBody();

    return "refresh".equals(claims.get("type")); // 1번의 .claim값 활용
}
```
- Refresh API에서 전달된 토큰이 정말 RefreshToken인지 검증하기 위해 isRefreshToken() 메서드를 추가함
- **AccessToken이 refresh API에 전달되는 것을 방지하는 용도**


## 💬리뷰 요구사항(선택)
없음