### PR TITLE
refactor: 투두 카테고리 API에 컬러 팔레트 추가

### DIFF
--- a/src/test/http/todo/todo.http
+++ b/src/test/http/todo/todo.http
@@ -1,4 +1,4 @@
-@accessToken = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJqYWVoeXVuOTkiLCJpYXQiOjE3Njc0MjMyMDMsImV4cCI6MTc2NzQyNjgwM30.d1xx8X7LEgBMRnHlRVP0PpHaJMhArzb9VftTiU2TbdU
+@accessToken =
 
 ### 투두 카테고리 생성
 POST http://localhost:8080/api/todo-categories
@@ -7,7 +7,7 @@ Content-Type: application/json
 
 {
   "name": "운동",
-  "color": "#43434"
+  "color": "#FF8355"
 }
 
 ### 카테고리 삭제
@@ -24,7 +24,9 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 {
-  "name": "운동"
+  "name": "운동",
+  "color": "#FCDF2F"
+
 }
 
 ### 카테고리 수정 (색상만 수정)


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #81

## 📝작업 내용

투두 카테고리 API에 컬러 팔레트 추가하였습니다.

팔레트 값:
  ``"#D29AFA", "#6BEBFF", "#9AFF5B", "#FFAD36", 
  "#FF8355", "#FCDF2F", "#FF3D2F", "#FF9E97"``

## 💬리뷰 요구사항(선택)

