### PR TITLE
Fix/#109 fix OpenAI responses stable

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/aisummary/service/AiSummaryService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/aisummary/service/AiSummaryService.java
@@ -53,6 +53,12 @@ public class AiSummaryService {
 
     // 1. 파일 요약 API
     public AiSummaryResponseDataDTO summarizeFile(MultipartFile file, String language, Integer maxTokens, Long userIdOrNull) {
+        // PDF만 허용 (png/jpg 등은 400)
+        if (!isPdf(file)) {
+            throw new CustomException(ErrorCode.BAD_REQUEST, "PDF 파일만 업로드할 수 있습니다.");
+        }
+
+
         if (file == null || file.isEmpty()) {
             throw new CustomException(ErrorCode.BAD_REQUEST, "file은 필수입니다.");
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #109

## 📝작업 내용

### 1. OpenAI Responses API 요약 안정화
- `gpt-5-mini` 사용 시 요약 결과가 **중간에 끊기거나(incomplete)**,  
  **reasoning 토큰만 소모되고 실제 요약 텍스트가 내려오지 않는 문제**를 해결했습니다.
- `reasoning.effort = minimal` 옵션을 적용하여  
  **출력 토큰을 reasoning이 아닌 text에 우선 사용하도록 조정**했습니다.
- instructions에서 **목표 토큰(targetTokens)** 을 `max_output_tokens`보다 낮게 설정하여  
  문장이 중간에 끊기지 않도록 유도했습니다.

### 2. incomplete 응답 대응 로직 추가
- OpenAI 응답이 `status=incomplete` 이거나  
  `incomplete_details.reason = max_output_tokens` 인 경우를 감지하도록 개선했습니다.
- 요약 텍스트 추출 실패 또는 incomplete 발생 시  
  **1회 재시도 로직**을 추가했습니다.
  - 재시도 시 더 짧은 토큰 목표
  - 더 강한 완결 조건을 가진 instructions 사용

### 3. Responses API 응답 파싱 안정화
- Responses API의 다양한 응답 구조를 고려하여  
  요약 텍스트 추출 로직을 보강했습니다.
  - `output_text` 직접 존재하는 경우
  - `output[].content[].text`
  - `{ text: { value: "..." } }` 구조
  - reasoning-only 응답 fallback 처리
- 여러 content에 나뉜 텍스트를 안전하게 병합하도록 개선했습니다.

### 4. 로그 보강 (디버깅/운영 안정성)
- OpenAI 요청/재시도 시점에 다음 정보를 로그로 남기도록 추가했습니다.
  - model
  - language
  - maxOutputTokens
  - 입력 텍스트 길이(inputChars)
- retry 실패, 텍스트 추출 실패 시 **응답 전체를 로그로 출력**하여 원인 추적 가능하도록 했습니다.

### 5. PDF 요약 처리 안정성 강화
- PDF 텍스트 추출 시 입력 길이를 제한하여 OpenAI 입력 초과를 방지했습니다.
- 요약 성공 여부를 `hasFullSummary` 로 명확히 관리하도록 흐름을 정리했습니다.
- PNG 등 **PDF가 아닌 파일 업로드 시 예외 발생 원인을 확인**하고,  
  추후 명확한 400 처리 기준을 적용할 수 있도록 구조를 정리했습니다.

### 6. 결과
- PNG 파일 올렸을 경우에 400 에러 오는 것 확인
- 기존에 끊겨서 나오던 요약본 제대로 오는 것 확인

<img width="1153" height="444" alt="image" src="https://github.com/user-attachments/assets/e39cabcc-2f95-4cf8-bf91-424f1fa56230" />

<img width="1254" height="312" alt="image" src="https://github.com/user-attachments/assets/086c90ab-e1dd-47f2-b88c-ce66414c4b45" />


