### PR TITLE
Fix/#119 sync response with api doc

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.util.Random;
 import java.util.UUID;
 
 @Service
@@ -81,6 +82,22 @@ public class AuthService {
         );
     }
 
+    // 닉네임 임의 생성
+    public String generateNickname() {
+        String chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+        Random random = new Random();
+        StringBuilder suffix = new StringBuilder();
+
+        // 3~4자리 랜덤 생성 (길이 6~7자 맞추기 위함)
+        int length = 4;
+
+        for (int i = 0; i < length; i++) {
+            suffix.append(chars.charAt(random.nextInt(chars.length())));
+        }
+
+        return "user" + suffix;  // 예: user2k1, user9ab3
+    }
+
     // 회원가입
     public SignupResponseDTO signup(SignupRequestDTO req, MultipartFile profileImage) {
         // id = 1 → 0P 기본 뱃지
@@ -113,7 +130,7 @@ public class AuthService {
                 .phoneNumber(req.getPhoneNumber())
                 .email(req.getEmail())
                 .name(req.getName())
-                .nickname("action_" + UUID.randomUUID().toString().substring(0, 8))
+                .nickname(generateNickname())
                 .profileImageUrl(profileImageUrl)
                 .birthday(LocalDate.parse(req.getBirthday())) // 문자열 날짜 파싱
                 .badge(defaultBadge)

--- a/src/main/java/com/req2res/actionarybe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/comment/controller/CommentController.java
@@ -178,7 +178,7 @@ public class CommentController {
             )
     })
     @GetMapping("/{postId}/comments")
-    public Response<GetCommentResponseDTO> getLatestPosts(
+    public Response<GetCommentResponseDTO> getLatestComments(
             @RequestParam(defaultValue = "0", required = false) int page,
             @PathVariable("postId") Long postId
     ) {

--- a/src/main/java/com/req2res/actionarybe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/comment/controller/CommentController.java
@@ -178,7 +178,7 @@ public class CommentController {
             )
     })
     @GetMapping("/{postId}/comments")
-    public Response<GetCommentResponseDTO> getLatestComments(
+    public Response<GetCommentResponseDTO> getLatestPosts(
             @RequestParam(defaultValue = "0", required = false) int page,
             @PathVariable("postId") Long postId
     ) {

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/CreatePostResponseDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/CreatePostResponseDTO.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class CreatePostResponseDTO {
-    private Long id;
+    private Long postId;
     private String title;
     private String nickname;
     private LocalDateTime createdAt;

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/CreatePostResponseDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/CreatePostResponseDTO.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class CreatePostResponseDTO {
-    private Long postId;
+    private Long id;
     private String title;
     private String nickname;
     private LocalDateTime createdAt;

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/PageInfoDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/PageInfoDTO.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class PageInfoDTO {
-    private int pageNum;
-    private int pageSize;
+    private int page;
+    private int size;
     private Long totalElements;
     private int totalPages;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/PageInfoDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/PageInfoDTO.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class PageInfoDTO {
-    private int page;
-    private int size;
+    private int pageNum;
+    private int pageSize;
     private Long totalElements;
     private int totalPages;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/PostInfoDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/PostInfoDTO.java
@@ -8,10 +8,10 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class PostInfoDTO {
-    private Long postId;
+    private Long id;
     private String type;
     private String title;
-    private String textContent;
-    private int commentCount;
+    private String text;
+    private int commentsCount;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/PostInfoDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/PostInfoDTO.java
@@ -8,10 +8,10 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class PostInfoDTO {
-    private Long id;
+    private Long postId;
     private String type;
     private String title;
-    private String text;
-    private int commentsCount;
+    private String textContent;
+    private int commentCount;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/PostSummaryDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/PostSummaryDTO.java
@@ -8,10 +8,10 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class PostSummaryDTO {
-    private Long id;
+    private Long postId;
     private String type;
     private String title;
     private String nickname;
-    private int commentsCount;
+    private int commentCount;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/PostSummaryDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/PostSummaryDTO.java
@@ -8,10 +8,10 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class PostSummaryDTO {
-    private Long postId;
+    private Long id;
     private String type;
     private String title;
     private String nickname;
-    private int commentCount;
+    private int commentsCount;
     private LocalDateTime createdAt;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET_KEY}
-    access-token-expiration-ms: 10800000  # 1시간
+    access-token-expiration-ms: 10800000  # 1시간 -> 3시간(임시)
 
   cloud:
     aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET_KEY}
-    access-token-expiration-ms: 3600000  # 1시간
+    access-token-expiration-ms: 10800000  # 1시간
 
   cloud:
     aws:


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#119 )

## 📝작업 내용
- api명세서와 response 변수명 일치 (api명세서 기준으로)
- accessToken 임시로 연동하는 동안만 1시간 -> 3시간 연장 (이전 PR에서 반영 안됐었음)
- 닉네임 action_1944d19c 형식이 너무 길어서, UI에서 잘리는 문제 해결 (user0000 형식으로 변경 ex. userfhp1) (이전 PR에서 반영 안됐었음)


## 💬리뷰 요구사항(선택)
없음
