### PR TITLE
fix: #125 - accessToken 만료 기간 3시간으로 복귀

### DIFF
--- a/src/main/java/com/req2res/actionarybe/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/req2res/actionarybe/global/security/JwtTokenProvider.java
@@ -22,7 +22,7 @@ public class JwtTokenProvider {
     public JwtTokenProvider(
             CustomMemberDetailsService userDetailsService,
             @Value("${jwt.secret:local-demo-secret-change-me-12345678901234567890}") String secret,
-            @Value("${jwt.access-token-expiration-ms:30000}") long accessMs
+            @Value("${jwt.access-token-expiration-ms:10800000}") long accessMs
     ) {
         this.userDetailsService = userDetailsService;
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -35,7 +35,7 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET_KEY}
-    access-token-expiration-ms: 30000  # 1시간
+    access-token-expiration-ms: 10800000  # 1시간 -> 3시간(임시)
 
   cloud:
     aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET_KEY}
-    access-token-expiration-ms: 30000  # 1시간 -> 3시간(임시)
+    access-token-expiration-ms: 10800000  # 1시간 -> 3시간(임시)
 
   cloud:
     aws:


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#125 )

## 📝작업 내용
- accessToken 만료기간 3시간으로 복귀 (refreshToken test 위해 30초로 바꿨었음)


## 💬리뷰 요구사항(선택)
없음