### PR TITLE
fix: #127 - 게시글 생성에서 images는 선택사항으로 변경

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
@@ -101,7 +101,7 @@ public class PostController {
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public Response<CreatePostResponseDTO> createPost(
-            @RequestPart("images") List<MultipartFile> images,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
             @RequestPart("post") CreatePostRequestDTO createPostRequestDTO,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#127 )

## 📝작업 내용
- 게시글 생성에서 사진은 선택사항으로 변경

## 💬리뷰 요구사항(선택)
없음