### PR TITLE
Fix/#132 comment notification to me error

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/comment/service/CommentService.java
@@ -7,7 +7,6 @@ import com.req2res.actionarybe.domain.member.entity.Member;
 import com.req2res.actionarybe.domain.member.repository.MemberRepository;
 import com.req2res.actionarybe.domain.notification.dto.NotificationCreateRequestDTO;
 import com.req2res.actionarybe.domain.notification.entity.NotificationType;
-import com.req2res.actionarybe.domain.notification.repository.NotificationRepository;
 import com.req2res.actionarybe.domain.notification.service.NotificationService;
 import com.req2res.actionarybe.domain.post.dto.PageInfoDTO;
 import com.req2res.actionarybe.domain.post.entity.Post;

--- a/src/main/java/com/req2res/actionarybe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/comment/service/CommentService.java
@@ -40,7 +40,7 @@ public class CommentService {
 
         // 본인 게시글에 댓글 생성 알림
         NotificationCreateRequestDTO commentNoti = NotificationCreateRequestDTO.of(
-                memberId,
+                post.getMember().getId(),
                 NotificationType.COMMENT,
                 "게시글에 답글이 달렸습니다.",
                 request.getContent(),


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#132 )

## 📝작업 내용
- 게시글의 댓글 달릴 시, '댓글을 단 member'에게 알림가는 오류 해결 ('게시글 쓴 member'에게 알림 전송되게 기능 수정함)

## 💬리뷰 요구사항(선택)
없음