### PR TITLE
Feat/#134 notification read

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/notification/controller/NotificationController.java
@@ -195,4 +195,34 @@ public class NotificationController {
         return ResponseEntity.ok(Response.success("", data));
     }
 
+    // 3. 알림 읽음 처리 API
+    @Operation(
+            summary = "알림 단건 읽음 처리 API",
+            description = """
+                알림을 클릭했을 때 해당 알림의 isRead를 true로 변경합니다.
+                내 알림만 읽음 처리 가능하며, 이미 읽음인 경우에도 200 OK로 응답합니다.
+                """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패(토큰 없음/만료)", content = @Content),
+            @ApiResponse(responseCode = "403", description = "내 알림이 아님", content = @Content),
+            @ApiResponse(responseCode = "404", description = "알림 없음", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<Response<NotificationGetResponseDTO>> readNotification(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long notificationId
+    ) {
+        String loginId = userDetails.getUsername();
+
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        NotificationGetResponseDTO data = notificationService.markAsRead(member.getId(), notificationId);
+
+        return ResponseEntity.ok(Response.success("알림을 읽음 처리했습니다.", data));
+    }
+
 }

--- a/src/main/java/com/req2res/actionarybe/domain/notification/dto/NotificationCreateRequestDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/notification/dto/NotificationCreateRequestDTO.java
@@ -1,5 +1,5 @@
 package com.req2res.actionarybe.domain.notification.dto;
-//알림 생성할 때 쓰는 request dto
+// 알림 생성할 때 쓰는 request dto
 
 import com.req2res.actionarybe.domain.notification.entity.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,21 +12,42 @@ import lombok.Getter;
 @AllArgsConstructor(staticName = "of")
 public class NotificationCreateRequestDTO {
 
-    @Schema(description = "알림을 받을 사용자 ID", example = "7")
+    @Schema(
+            description = "알림을 받을 사용자 ID",
+            example = "1"
+    )
     @NotNull(message = "receiverId는 필수입니다.")
     private Long receiverId;
 
-    @Schema(description = "알림 유형", example = "POINT", allowableValues = {"COMMENT","POINT","TODO_ALL_DONE","DAILY_STUDY_SUMMARY"})
+    @Schema(
+            description = "알림 유형",
+            example = "COMMENT",
+            allowableValues = {"COMMENT","POINT","TODO_ALL_DONE","DAILY_STUDY_SUMMARY"}
+    )
     @NotNull(message = "type은 필수입니다.")
     private NotificationType type;
 
-    @Schema(description = "알림 제목", example = "포인트가 적립되었습니다.")
+    @Schema(
+            description = "알림 제목",
+            example = "내 게시글에 댓글이 달렸습니다."
+    )
     @NotBlank(message = "title은 필수입니다.")
     private String title;
 
-    @Schema(description = "알림 상세 내용", example = "공부시간 기록으로 100P가 적립되었어요.")
+    @Schema(
+            description = "알림 상세 내용",
+            example = "다현님이 댓글을 남겼어요."
+    )
     private String content;
 
-    @Schema(description = "알림 클릭 시 이동 경로(없으면 null)", example = "/mypage/points", nullable = true)
+    @Schema(
+            description = """
+            알림 클릭 시 이동 경로  
+            - COMMENT 타입만 사용  
+            - 그 외 타입은 null
+            """,
+            example = "/posts/25",
+            nullable = true
+    )
     private String link;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/notification/entity/Notification.java
+++ b/src/main/java/com/req2res/actionarybe/domain/notification/entity/Notification.java
@@ -4,6 +4,7 @@ import com.req2res.actionarybe.global.Timestamped;
 import com.req2res.actionarybe.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -53,4 +54,13 @@ public class Notification extends Timestamped {
                 .readAt(null)
                 .build();
     }
+
+    public void markAsRead() {
+        if (Boolean.TRUE.equals(this.isRead)) {
+            return; // 멱등성
+        }
+        this.isRead = true;
+        this.readAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/req2res/actionarybe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/notification/service/NotificationService.java
@@ -132,8 +132,6 @@ public class NotificationService {
         create(req);
     }
 
-
-    //-------------------------------------------------
     // 2. 알림 조회 API
     @Transactional(readOnly = true)
     public List<NotificationGetResponseDTO> getMyNotifications(Long memberId, Integer limit) {
@@ -157,4 +155,23 @@ public class NotificationService {
                 .map(NotificationGetResponseDTO::from)
                 .toList();
     }
+
+    // 3.알림 읽음 처리 API
+    @Transactional
+    public NotificationGetResponseDTO markAsRead(Long memberId, Long notificationId) {
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        // 내 알림인지 검증
+        if (!notification.getReceiver().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.NOTIFICATION_FORBIDDEN);
+        }
+
+        // 멱등 처리
+        notification.markAsRead();
+
+        return NotificationGetResponseDTO.from(notification);
+    }
+
 }

--- a/src/main/java/com/req2res/actionarybe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/notification/service/NotificationService.java
@@ -37,12 +37,17 @@ public class NotificationService {
         Member receiver = memberRepository.findById(request.getReceiverId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
+        // 정책: COMMENT만 link 허용, 나머지는 link = null
+        String link = (request.getType() == NotificationType.COMMENT)
+                ? request.getLink()
+                : null;
+
         Notification notification = Notification.create(
                 receiver,
                 request.getType(),
                 request.getTitle(),
                 request.getContent(),
-                request.getLink()
+                link
         );
 
         Notification saved = notificationRepository.save(notification);
@@ -57,7 +62,7 @@ public class NotificationService {
                 NotificationType.TODO_ALL_DONE,
                 "오늘의 투두를 모두 완료했어요 🎉",
                 "오늘(" + date + ")의 투두를 전부 완료했습니다!",
-                "/todos?date=" + date
+                null
         );
         create(req);
     }
@@ -77,7 +82,7 @@ public class NotificationService {
                 NotificationType.POINT,
                 "포인트가 적립되었습니다.",
                 reason + "로 " + point + "P가 적립되었어요.",
-                "/mypage/points"
+                null
         );
         create(req);
     }
@@ -121,7 +126,7 @@ public class NotificationService {
                 NotificationType.DAILY_STUDY_SUMMARY,
                 "오늘 공부량 리포트",
                 summaryText,
-                "/study/report"
+                null
         );
 
         create(req);

--- a/src/main/java/com/req2res/actionarybe/domain/study/scheduler/DailyStudySummaryScheduler.java
+++ b/src/main/java/com/req2res/actionarybe/domain/study/scheduler/DailyStudySummaryScheduler.java
@@ -1,0 +1,54 @@
+package com.req2res.actionarybe.domain.study.scheduler;
+
+import com.req2res.actionarybe.domain.notification.service.NotificationService;
+import com.req2res.actionarybe.domain.study.service.StudyService;
+import com.req2res.actionarybe.domain.studyTime.entity.Type;
+import com.req2res.actionarybe.domain.studyTime.repository.StudyTimeManualRepository;
+import com.req2res.actionarybe.domain.studyTime.repository.StudyTimeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DailyStudySummaryScheduler {
+
+    private final StudyService studyService; // 공부량 집계 로직 있는 서비스
+    private final NotificationService notificationService;
+    private final StudyTimeRepository studyTimeRepository;
+    private final StudyTimeManualRepository studyTimeManualRepository;
+
+    @Scheduled(cron = "0 */1 * * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void sendDailyStudySummary() {
+        System.out.println("[Scheduler] fired");
+
+        var today = java.time.LocalDate.now();
+        var start = today.atStartOfDay();
+        var end = today.atTime(java.time.LocalTime.MAX);
+
+        // 자동
+        List<Long> autoUserIds = studyTimeRepository.findDistinctUserIdsStudiedToday(start, end, Type.STUDY);
+
+        // 수동
+        List<Long> manualUserIds = studyTimeManualRepository.findDistinctUserIdsByManualDate(today);
+
+        List<Long> userIds = java.util.stream.Stream.concat(autoUserIds.stream(), manualUserIds.stream())
+                .distinct()
+                .toList();
+        studyTimeManualRepository.findAll().forEach(x -> System.out.println("[DB] " + x.getId() + " " + x.getUserId() + " " + x.getManualDate()));
+
+
+        for (Long userId : userIds) {
+            String summaryText = studyService.buildTodaySummaryText(userId);
+            notificationService.notifyDailyStudySummary(userId, summaryText);
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/req2res/actionarybe/domain/studyTime/repository/StudyTimeManualRepository.java
+++ b/src/main/java/com/req2res/actionarybe/domain/studyTime/repository/StudyTimeManualRepository.java
@@ -31,4 +31,24 @@ public interface StudyTimeManualRepository extends JpaRepository<StudyTimeManual
 		      and sm.manualDate between :startDate and :endDate
 		""")
 	long sumTodaySeconds(Long userId, LocalDate startDate, LocalDate endDate);
+
+	// 오늘 수동 등록한 유저 목록
+	@Query("""
+        select distinct stm.userId
+        from StudyTimeManual stm
+        where stm.manualDate = :date
+    """)
+	List<Long> findDistinctUserIdsByManualDate(@Param("date") LocalDate date);
+
+	// 오늘 수동 등록 공부시간 합계(초)
+	@Query("""
+        select coalesce(sum(stm.durationSecond), 0)
+        from StudyTimeManual stm
+        where stm.userId = :userId
+          and stm.manualDate = :date
+    """)
+	int sumManualStudySecondsByUserIdAndDate(
+			@Param("userId") Long userId,
+			@Param("date") LocalDate date
+	);
 }

--- a/src/main/java/com/req2res/actionarybe/domain/studyTime/repository/StudyTimeRepository.java
+++ b/src/main/java/com/req2res/actionarybe/domain/studyTime/repository/StudyTimeRepository.java
@@ -43,4 +43,34 @@ public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
 		  AND st.createdAt BETWEEN :start AND :end
 		""")
 	List<StudyTime> findStudyTimeByMember(Member member, Type type, LocalDateTime start, LocalDateTime end);
+
+	// 오늘 공부한 유저 목록 (자동 기록)
+	@Query("""
+    select distinct st.studyParticipant.member.id
+    from StudyTime st
+    where st.createdAt between :start and :end
+      and st.type = :studyType
+""")
+	List<Long> findDistinctUserIdsStudiedToday(
+			@Param("start") LocalDateTime start,
+			@Param("end") LocalDateTime end,
+			@Param("studyType") Type studyType
+	);
+
+
+	// 유저별 오늘 공부시간 합계(초) (자동 기록)
+	@Query("""
+    select coalesce(sum(st.durationSecond), 0)
+    from StudyTime st
+    where st.studyParticipant.member.id = :userId
+      and st.createdAt between :start and :end
+      and st.type = :studyType
+""")
+	int sumStudySecondsTodayByUserId(
+			@Param("userId") Long userId,
+			@Param("start") LocalDateTime start,
+			@Param("end") LocalDateTime end,
+			@Param("studyType") Type studyType
+	);
+
 }

--- a/src/main/java/com/req2res/actionarybe/global/exception/ErrorCode.java
+++ b/src/main/java/com/req2res/actionarybe/global/exception/ErrorCode.java
@@ -58,6 +58,10 @@ public enum ErrorCode {
 	STUDY_PARTICIPATION_TIME_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "참여 시간은 30분 이상이어야 포인트가 적립됩니다."),
 	TODO_POINT_ALREADY_EARNED(HttpStatus.CONFLICT, "이미 해당 투두 완료 포인트를 적립했습니다."),
 
+	// notification
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 알림을 찾을 수 없습니다."),
+	NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "내 알림만 읽음 처리할 수 있습니다."),
+
 	//search
 	SEARCH_NOT_FOUND(HttpStatus.NOT_FOUND, "검색 결과를 찾을 수 없습니다."),
 


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #134

## 📝작업 내용

## 1️⃣ 알림 link 정책 정리 (댓글만 이동 가능)

### 정책 개요
- 알림 `link`는 **프론트엔드 라우팅 경로**이며 백엔드 API 엔드포인트가 아님
- **댓글 알림(COMMENT)만 link를 가질 수 있음**
- 그 외 알림 타입은 모두 `null`로 저장되도록 정책 적용

### 알림 타입별 link 정책
- COMMENT → `/posts/{postId}`
- POINT → `null`
- TODO_ALL_DONE → `null`
- DAILY_STUDY_SUMMARY → `null`

### 적용 위치
- `NotificationService.create()`
    - 알림 타입 기준으로 link 값을 **강제 보정**
    - COMMENT가 아닌 경우, 요청에 link가 포함되어 있어도 `null` 처리


---

## 2️⃣ 알림 읽음 처리 API 구현

### 엔드포인트
```PATCH /api/notifications/{notificationId}/read```

### 동작
- 로그인 사용자 기준으로 **내 알림만** 읽음 처리 가능
- `isRead = true`로 변경
- `readAt` 시간 저장
- 이미 읽은 알림에 대해서도 **멱등성 보장 (200 OK 반환)**

### 예외 처리
- `401 UNAUTHORIZED` : 인증 실패
- `403 FORBIDDEN` : 내 알림이 아닌 경우
- `404 NOT_FOUND` : 알림이 존재하지 않는 경우


---

## 3️⃣ 공부량 리포트 알림 (자정 발송) 스케줄러 추가

### 목적
- 매일 **00:00**에 “오늘 공부량 리포트” 알림 생성
- 개발/테스트 편의를 위해 크론을 **1분 단위 실행**으로 임시 변경 가능

### 구현 위치
- `domain/study/scheduler/DailyStudySummaryScheduler`

### 동작 흐름
1. 스케줄러 실행
2. `StudyService.findUsersStudiedToday()` 호출
3. 공부 기록이 있는 사용자 ID 목록(`userIds`) 조회
4. 각 사용자에 대해
    - `studyService.buildTodaySummaryText(userId)`
    - `notificationService.notifyDailyStudySummary(userId, summaryText)` 호출

### DB 집계 기준
- **자동 기록**
    - `study_time`
    - `study_participant` 와 `member` 조인 기반
- **수동 기록**
    - `study_time_manual`
    - `manual_date = 오늘 날짜` 기준
- 자동 + 수동 기록 결과를 합쳐 **중복 제거(distinct)** 후 사용자 ID 목록 생성


## 💬리뷰 요구사항(선택)

