### PR TITLE
feat:#155-투두 완료시 포인트 적립 API 호출 추가

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/point/dto/TodoCompletionPointRequestDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/point/dto/TodoCompletionPointRequestDTO.java
@@ -14,4 +14,8 @@ public class TodoCompletionPointRequestDTO {
     @Schema(description = "완료한 투두 ID", example = "55", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "todoId는 필수입니다.")
     private Long todoId;
+
+    public TodoCompletionPointRequestDTO(Long todoId) {
+        this.todoId = todoId;
+    }
 }

--- a/src/main/java/com/req2res/actionarybe/domain/point/scheduler/StudyTimePointScheduler.java
+++ b/src/main/java/com/req2res/actionarybe/domain/point/scheduler/StudyTimePointScheduler.java
@@ -21,7 +21,7 @@ public class StudyTimePointScheduler {
     private final MemberRepository memberRepository;
 
     // 매일 00:00 실행
-    //테스트용으로 1분마다 실행
+    // 테스트용으로 1분마다 실행
     @Scheduled(cron = "0 * * * * *")
     public void earnDailyStudyTimePoints() {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #155

## 📝작업 내용

투두 완료시 포인트 적립 API 호출 추가

### 작업 결과
- 투두 1개 완료시 1P씩 오는 것 확인
- 5개까지만 오는 것도 확인
<img width="659" height="437" alt="image" src="https://github.com/user-attachments/assets/fcc7ae71-1d0d-4f66-a15f-37102def057d" />

- 공개용 포인트 조회에도 5P 정상적으로 쌓이는 것 확인
<img width="475" height="375" alt="image" src="https://github.com/user-attachments/assets/f916611a-4809-460c-8597-3fec81e70779" />

- 사이드바용 포인트 조회에도 5P 정상적으로 쌓이는 것 확인
<img width="281" height="192" alt="image" src="https://github.com/user-attachments/assets/4b73171e-f28c-48a3-b6ec-6fa4b7eee0e9" />

