### PR TITLE
fix:#166-투두 달성 실패 에러 수정

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/point/service/PointService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/point/service/PointService.java
@@ -20,6 +20,7 @@ import com.req2res.actionarybe.global.exception.CustomException;
 import com.req2res.actionarybe.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -184,6 +185,19 @@ public class PointService {
                 PointSource.STUDY_PARTICIPATION,
                 userPoint.getTotalPoint()
         );
+    }
+
+
+    /**
+     * To-do 상태 변경 트랜잭션과 분리하기 위한 래퍼
+     * - 포인트 적립 실패/중복이 나도 to-do 상태 변경은 커밋되게 함
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public TodoCompletionPointResponseDTO earnTodoCompletionPointNewTx(
+            Long loginMemberId,
+            TodoCompletionPointRequestDTO request
+    ) {
+        return earnTodoCompletionPoint(loginMemberId, request);
     }
 
     // 3. to-do 완료시 포인트 적립 API


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #166

## 📝작업 내용

- 투두 상태를 FAILED → DONE 으로 변경할 때 500 에러가 발생하던 문제를 수정했습니다.
- 원인: 투두 상태 변경 트랜잭션 내에서 **포인트 적립 로직이 RuntimeException을 발생시키며 트랜잭션이 rollback-only 상태로 마킹**되던 문제였습니다.
- 해결:
  - 투두 상태 변경(핵심 로직)과 포인트 적립(부가 로직)을 **트랜잭션 분리**하여 처리했습니다.
  - 포인트 적립 로직을 `REQUIRES_NEW` 트랜잭션으로 분리해,  
    포인트 중복 지급 등 예외 발생 시에도 **투두 상태 변경은 정상 커밋**되도록 수정했습니다.
  - 이미 포인트를 받은 투두의 경우 로그만 남기고 정상 흐름으로 처리하도록 보완했습니다.

### 🧪 테스트 내용
- FAILED → DONE 상태 변경 시
  - 포인트 미지급 투두: 상태 변경 + 포인트 정상 적립
  - 이미 포인트 지급된 투두: 상태 변경은 성공, 포인트는 스킵
- FAILED 처리 시 포인트 적립이 발생하지 않는 것 확인


## 💬리뷰 요구사항(선택)


