### PR TITLE
feat:#173-캘린더용 투두 기간 집계 기능 API 구현 완료

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/todo/controller/TodoCalendarController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/controller/TodoCalendarController.java
@@ -1,0 +1,74 @@
+package com.req2res.actionarybe.domain.todo.controller;
+
+import com.req2res.actionarybe.domain.member.entity.Member;
+import com.req2res.actionarybe.domain.member.repository.MemberRepository;
+import com.req2res.actionarybe.domain.todo.dto.TodoCalendarDoneSummaryDTO;
+import com.req2res.actionarybe.domain.todo.service.TodoCalendarService;
+import com.req2res.actionarybe.global.Response;
+import com.req2res.actionarybe.global.exception.CustomException;
+import com.req2res.actionarybe.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/todos/calendar")
+public class TodoCalendarController {
+
+    private final TodoCalendarService todoCalendarService;
+    private final MemberRepository memberRepository;
+
+    @Operation(
+            summary = "캘린더 월별 DONE 투두 집계 조회",
+            description = """
+                    캘린더 화면에서 사용하기 위한 API입니다.
+                    <br/>
+                    선택한 연/월에 해당하는 기간 동안,
+                    <b>DONE 상태인 투두만</b> 날짜별로 집계하여 반환합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "캘린더 월별 DONE 투두 집계 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (year/month 값 오류)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)")
+    })
+    @GetMapping("/summary/monthly")
+    public Response<List<TodoCalendarDoneSummaryDTO>> getMonthlyDoneSummary(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetails userDetails,
+
+            @Parameter(description = "조회할 연도", example = "2026", required = true)
+            @RequestParam int year,
+
+            @Parameter(description = "조회할 월 (1~12)", example = "1", required = true)
+            @RequestParam int month
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String loginId = userDetails.getUsername();
+
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        Long userId = member.getId();
+
+        List<TodoCalendarDoneSummaryDTO> data =
+                todoCalendarService.getMonthlyDoneSummary(userId, year, month);
+
+        return Response.success("캘린더 월별 DONE 투두 집계 조회에 성공했습니다.", data);
+    }
+}
+

--- a/src/main/java/com/req2res/actionarybe/domain/todo/dto/TodoCalendarDoneSummaryDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/dto/TodoCalendarDoneSummaryDTO.java
@@ -1,0 +1,25 @@
+package com.req2res.actionarybe.domain.todo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "캘린더 월별 DONE 투두 날짜별 집계 DTO")
+public class TodoCalendarDoneSummaryDTO {
+
+    @Schema(
+            description = "투두 완료(DONE) 날짜",
+            example = "2026-01-21"
+    )
+    private LocalDate date;
+
+    @Schema(
+            description = "해당 날짜에 완료(DONE)된 투두 개수",
+            example = "2"
+    )
+    private long doneCount;
+}

--- a/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoDoneCountByDate.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoDoneCountByDate.java
@@ -1,0 +1,9 @@
+package com.req2res.actionarybe.domain.todo.repository;
+
+import java.time.LocalDate;
+
+public interface TodoDoneCountByDate {
+    LocalDate getDate();
+    Long getDoneCount();
+}
+

--- a/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoRepository.java
@@ -31,4 +31,21 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     boolean existsByCategoryIdAndStatuses(@Param("userId") Long userId,
                                           @Param("categoryId") Long categoryId,
                                           @Param("statuses") Collection<Todo.Status> statuses);
+
+    //status=DONE인 상태인 투두 개수 세는 메소드
+    @Query("""
+        select t.date as date, count(t) as doneCount
+        from Todo t
+        where t.userId = :userId
+          and t.status = :status
+          and t.date between :startDate and :endDate
+        group by t.date
+        order by t.date asc
+    """)
+    List<TodoDoneCountByDate> countDoneTodosByDateInMonth(
+            @Param("userId") Long userId,
+            @Param("status") Todo.Status status,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }

--- a/src/main/java/com/req2res/actionarybe/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/service/TodoCalendarService.java
@@ -1,0 +1,56 @@
+package com.req2res.actionarybe.domain.todo.service;
+
+import com.req2res.actionarybe.domain.todo.dto.TodoCalendarDoneSummaryDTO;
+import com.req2res.actionarybe.domain.todo.entity.Todo;
+import com.req2res.actionarybe.domain.todo.repository.TodoDoneCountByDate;
+import com.req2res.actionarybe.domain.todo.repository.TodoRepository;
+import com.req2res.actionarybe.global.exception.CustomException;
+import com.req2res.actionarybe.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoCalendarService {
+
+    private final TodoRepository todoRepository;
+
+    public List<TodoCalendarDoneSummaryDTO> getMonthlyDoneSummary(
+            Long userId,
+            int year,
+            int month
+    ) {
+        // month 유효성 검사
+        if (month < 1 || month > 12) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        // 해당 월의 시작일 ~ 말일 계산
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        // DONE 상태만 집계
+        List<TodoDoneCountByDate> result =
+                todoRepository.countDoneTodosByDateInMonth(
+                        userId,
+                        Todo.Status.DONE,
+                        startDate,
+                        endDate
+                );
+
+        // Projection → DTO 변환
+        return result.stream()
+                .map(r -> new TodoCalendarDoneSummaryDTO(
+                        r.getDate(),
+                        r.getDoneCount()
+                ))
+                .toList();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #173

## 📝작업 내용

- 캘린더 화면에서 날짜별로 DONE 상태 투두 개수(아이콘) 를 표시하기 위한 월 단위 투두 집계 API를 신규 구현했습니다.
- year, month를 기준으로 해당 월에 속한 투두 중 DONE 상태인 투두만 날짜별로 집계하여 반환하도록 설계했습니다.
- 기존 “특정 날짜 투두 조회 API”와 역할을 분리하여 캘린더 렌더링(집계)과 상세 리스트 조회(목록)를 명확히 구분했습니다.


## 💬리뷰 요구사항(선택)


