### PR TITLE
Fix/#165 post update

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
@@ -249,10 +249,11 @@ public class PostController {
     @PatchMapping("/{post_id}")
     public Response<UpdatePostResponseDTO> updatePost(
             @PathVariable("post_id") Long postId,
-            @RequestPart(value = "images", required = false) UpdateImageRequestDTO images,
+            @RequestPart(value = "addImages", required = false) List<MultipartFile> addImages,
+            @RequestPart(value = "delImages", required = false) DeleteImagesRequestDTO delImages,
             @RequestPart(value = "post", required = false) UpdatePostRequestDTO posts
     ){
-        UpdatePostResponseDTO result = postService.updatePost(postId, images, posts);
+        UpdatePostResponseDTO result = postService.updatePost(postId, addImages, delImages, posts);
         return Response.success("게시글 수정 성공", result);
     }
 

--- a/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/controller/PostController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/req2res/actionarybe/domain/post/dto/DeleteImagesRequestDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/dto/DeleteImagesRequestDTO.java
@@ -1,0 +1,12 @@
+package com.req2res.actionarybe.domain.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class DeleteImagesRequestDTO {
+    List<String> imageUrl;
+}

--- a/src/main/java/com/req2res/actionarybe/domain/post/service/PostService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/service/PostService.java
@@ -133,10 +133,12 @@ public class PostService {
 
     // 이미지 삭제
     @Transactional
-    public void delPostImages(String[] delImages, Post post) {
+    public void delPostImages(List<String> delImages, Post post) {
         // 이미지 삭제
         for(String imageUrl : delImages){
+            System.out.println("@%#@"+isDelImageInS3(imageUrl)+"@%#@");
             if(isDelImageInS3(imageUrl)){
+                System.out.println("I'm in");
                 imageService.deleteImage(imageUrl);
                 post.removeImage(imageUrl);
             }else{
@@ -147,19 +149,17 @@ public class PostService {
 
     // 게시글 수정
     @Transactional
-    public UpdatePostResponseDTO updatePost(Long post_id, UpdateImageRequestDTO imagesDTO, UpdatePostRequestDTO postDTO) {
+    public UpdatePostResponseDTO updatePost(Long post_id, List<MultipartFile> addImages, DeleteImagesRequestDTO delImagesDTO, UpdatePostRequestDTO postDTO) {
         Post post=postRepository.findById(post_id)
                 .orElseThrow(()->new CustomException(ErrorCode.POST_NOT_FOUND));
-        System.out.println("@^%#"+imagesDTO+"@&%#%@&");
 
-        if(imagesDTO == null && post == null){
+        if(addImages == null && postDTO == null && delImagesDTO == null){
             throw new CustomException(ErrorCode.EMPTY_UPDATE_REQUEST);
         }
 
-        if(imagesDTO != null){
-            if(imagesDTO.getDelImages()!=null) delPostImages(imagesDTO.getDelImages(), post);
-            if(imagesDTO.getAddImages()!=null) addPostImages(imagesDTO.getAddImages(), post);
-        }
+        if(delImagesDTO!=null) delPostImages(delImagesDTO.getImageUrl(), post);
+        if(addImages!=null) addPostImages(addImages, post);
+
         if(postDTO != null){
             if(postDTO.getType()!=null)
                 post.setType(Post.Type.valueOf(postDTO.getType())); // request의 type는 String이라, Post의 Type 자료형인 Post.Type(Enum) 타입 변환 필요

--- a/src/main/java/com/req2res/actionarybe/domain/post/service/PostService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/service/PostService.java
@@ -97,7 +97,7 @@ public class PostService {
 
         // 서버 꺼졌다가 켜져도, .getImages()하면 SQL 쿼리 날림 (@OneToMany(fetch = FetchType.LAZY이기에)
         List<String> images=post.getImages().stream()
-                .map(postImage->postImage.getImageUrl()).toList();
+                .map(PostImage::getImageUrl).toList();
 
         return new GetPostResponseDTO(
                 postInfo,
@@ -110,8 +110,7 @@ public class PostService {
     public boolean isDelImageInS3(String delImageUrl){
         Optional<PostImage> opt = Optional.ofNullable(postImageRepository.findByImageUrl(delImageUrl));
 
-        if(opt.isPresent()) return true;
-        else return false;
+        return opt.isPresent();
     }
 
     // 이미지 추가


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#165 )

## 📝작업 내용
- 기존: 게시글 이미지는 기존 이미지를 모두 지우고, 아예 프론트에서 **기존+추가되는 이미지**를 **한번에** 받으려고 했음
- 문제: 기존 이미지가 S3 url로 된 이미지를 프론트에 내려주기에, 이미 s3에 있는 이미지를 다시 S3로 보낼 수 없었음.
- 해결: 프론트측에서 **이미지 추가/삭제**를 **나눠서** 받도록 변경함 (그러면 s3의 이미지는 url을 통해 백에서 삭제, 이미지 첨부는 프론트에서 file형식으로 보내게 함)


## 💬리뷰 요구사항(선택)
없음