### PR TITLE
refactor:#190-response에 totaltodocount 필드 추가

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/todo/dto/TodoCalendarDoneSummaryDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/dto/TodoCalendarDoneSummaryDTO.java
@@ -8,11 +8,11 @@ import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
-@Schema(description = "캘린더 월별 DONE 투두 날짜별 집계 DTO")
+@Schema(description = "캘린더 월별 투두 날짜별 집계 DTO (DONE + TOTAL)")
 public class TodoCalendarDoneSummaryDTO {
 
     @Schema(
-            description = "투두 완료(DONE) 날짜",
+            description = "투두 날짜",
             example = "2026-01-21"
     )
     private LocalDate date;
@@ -22,4 +22,10 @@ public class TodoCalendarDoneSummaryDTO {
             example = "2"
     )
     private long doneCount;
+
+    @Schema(
+            description = "해당 날짜의 전체 투두 개수 (상태 무관, DONE 포함)",
+            example = "5"
+    )
+    private long totalTodoCount;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoDoneCountByDate.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoDoneCountByDate.java
@@ -5,5 +5,6 @@ import java.time.LocalDate;
 public interface TodoDoneCountByDate {
     LocalDate getDate();
     Long getDoneCount();
+    Long getTotalTodoCount();
 }
 

--- a/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoRepository.java
@@ -32,19 +32,26 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
                                           @Param("categoryId") Long categoryId,
                                           @Param("statuses") Collection<Todo.Status> statuses);
 
-    //status=DONE인 상태인 투두 개수 세는 메소드
+    /**
+     * 특정 월 범위에서 날짜별로
+     * - DONE 개수(doneCount)
+     * - 전체 투두 개수(totalTodoCount)
+     * 를 함께 집계한다.
+     */
     @Query("""
-        select t.date as date, count(t) as doneCount
+        select
+            t.date as date,
+            sum(case when t.status = :doneStatus then 1 else 0 end) as doneCount,
+            count(t) as totalTodoCount
         from Todo t
         where t.userId = :userId
-          and t.status = :status
           and t.date between :startDate and :endDate
         group by t.date
         order by t.date asc
     """)
-    List<TodoDoneCountByDate> countDoneTodosByDateInMonth(
+    List<TodoDoneCountByDate> countTodoSummaryByDateInMonth(
             @Param("userId") Long userId,
-            @Param("status") Todo.Status status,
+            @Param("doneStatus") Todo.Status doneStatus,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
     );

--- a/src/main/java/com/req2res/actionarybe/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/service/TodoCalendarService.java
@@ -36,9 +36,9 @@ public class TodoCalendarService {
         LocalDate startDate = yearMonth.atDay(1);
         LocalDate endDate = yearMonth.atEndOfMonth();
 
-        // DONE 상태만 집계
+        // 날짜별 DONE 개수 + 전체 개수 함께 집계
         List<TodoDoneCountByDate> result =
-                todoRepository.countDoneTodosByDateInMonth(
+                todoRepository.countTodoSummaryByDateInMonth(
                         userId,
                         Todo.Status.DONE,
                         startDate,
@@ -49,7 +49,8 @@ public class TodoCalendarService {
         return result.stream()
                 .map(r -> new TodoCalendarDoneSummaryDTO(
                         r.getDate(),
-                        r.getDoneCount()
+                        r.getDoneCount(),
+                        r.getTotalTodoCount()
                 ))
                 .toList();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #190

## 📝작업 내용

- 캘린더 월별 투두 기간 집계 API 응답에 `totalTodoCount` 필드 추가
- 날짜별로 **DONE 투두 개수(doneCount)** 와 **전체 투두 개수(totalTodoCount)** 를 함께 반환하도록 수정
- Projection 기반 집계 쿼리를 수정하여 DONE 집계와 전체 집계를 한 번의 쿼리로 처리
- 이에 따라 DTO 및 Service 로직을 명세에 맞게 리팩토링


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
