### PR TITLE
fix:#192-투두 카테고리 생성, 목록 조회 API에 startDate 필드 추가

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/todo/controller/TodoCategoryController.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/controller/TodoCategoryController.java
@@ -17,12 +17,14 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -145,7 +147,15 @@ public class TodoCategoryController {
     @GetMapping
     public ResponseEntity<Response<List<TodoCategoryListItemDTO>>> getMyCategories(
             @Parameter(hidden = true)
-            @AuthenticationPrincipal UserDetails userDetails
+            @AuthenticationPrincipal UserDetails userDetails,
+
+            @Parameter(
+                    description = "조회 기준 날짜 (이 날짜 기준 startDate <= date 인 카테고리만 반환). 미입력 시 오늘 날짜 기준",
+                    example = "2026-01-20"
+            )
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date
     ) {
         String loginId = userDetails.getUsername();
 
@@ -154,7 +164,8 @@ public class TodoCategoryController {
 
         Long userId = member.getId();
 
-        List<TodoCategoryListItemDTO> data = todoCategoryService.getCategory(userId);
+        // date가 null이면 서비스에서 today로 처리
+        List<TodoCategoryListItemDTO> data = todoCategoryService.getCategory(userId, date);
 
         return ResponseEntity.ok(Response.success("카테고리 목록 조회 성공", data));
     }

--- a/src/main/java/com/req2res/actionarybe/domain/todo/dto/category/TodoCategoryCreateRequestDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/dto/category/TodoCategoryCreateRequestDTO.java
@@ -1,10 +1,11 @@
 package com.req2res.actionarybe.domain.todo.dto.category;
-// 투두 카테고리 생성 API에서 사용하는 요청 DTO
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -28,4 +29,13 @@ public class TodoCategoryCreateRequestDTO {
     )
     @NotBlank(message = "카테고리 색상은 필수입니다.")
     private String color;
+
+    //카테고리 적용 날짜
+    @Schema(
+            description = "카테고리가 적용되기 시작하는 날짜 (이 날짜부터 카테고리가 노출됨)",
+            example = "2026-01-20"
+    )
+    @NotNull(message = "카테고리 시작 날짜는 필수입니다.")
+    private LocalDate startDate;
+
 }

--- a/src/main/java/com/req2res/actionarybe/domain/todo/dto/category/TodoCategoryCreateResponseDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/dto/category/TodoCategoryCreateResponseDTO.java
@@ -2,6 +2,8 @@ package com.req2res.actionarybe.domain.todo.dto.category;
 // 투두 카테고리 생성 API 응답 DTO
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,20 +13,19 @@ import lombok.Getter;
 @Schema(description = "투두 카테고리 생성 응답 DTO")
 public class TodoCategoryCreateResponseDTO {
 
-    // 카테고리 고유 ID
     @Schema(description = "카테고리 ID", example = "1")
     private Long categoryId;
 
-    // 카테고리 이름
     @Schema(description = "카테고리 이름", example = "공부")
     private String name;
 
-    // 카테고리 색상 (HEX)
     @Schema(description = "카테고리 색상 (HEX 코드),색상은 \\\\\\\"#D29AFA\\\\\\\", \\\\\\\"#6BEBFF\\\\\\\", \" +\n" +
             "                    \"\\\\\\\"#9AFF5B\\\\\\\", \\\\\\\"#FFAD36\\\\\\\",\\\\\\\"#FF8355\\\\\\\", \\\\\\\"#FCDF2F\\\\\\\", \\\\\\\"#FF3D2F\\\\\\\", \\\\\\\"#FF9E97\\\\\\\"중에만 가능합니다.\"", example = "#D29AFA")
     private String color;
 
-    // 카테고리 생성 시각
+    @Schema(description = "카테고리 적용 시작 날짜", example = "2026-01-20")
+    private LocalDate startDate;
+
     @Schema(description = "카테고리 생성 일시", example = "2025-12-30T13:45:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/todo/dto/category/TodoCategoryListItemDTO.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/dto/category/TodoCategoryListItemDTO.java
@@ -1,7 +1,8 @@
 package com.req2res.actionarybe.domain.todo.dto.category;
-// 투두 카테고리 목록 조회 API에서 사용하는 DTO
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,19 +12,21 @@ import lombok.Getter;
 @Schema(description = "투두 카테고리 목록 조회 아이템 DTO")
 public class TodoCategoryListItemDTO {
 
-    // 카테고리 고유 ID
     @Schema(description = "카테고리 ID", example = "1")
     private Long categoryId;
 
-    // 카테고리 이름
     @Schema(description = "카테고리 이름", example = "공부")
     private String name;
 
-    // 카테고리 색상 (HEX)
     @Schema(description = "카테고리 색상 (HEX 코드)", example = "#D29AFA")
     private String color;
 
-    // 카테고리 생성 시각
+    @Schema(
+            description = "카테고리가 적용되기 시작하는 날짜 (이 날짜부터 카테고리 노출)",
+            example = "2026-01-20"
+    )
+    private LocalDate startDate;
+
     @Schema(description = "카테고리 생성 일시", example = "2025-12-30T13:45:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/req2res/actionarybe/domain/todo/entity/TodoCategory.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/entity/TodoCategory.java
@@ -4,6 +4,8 @@ import com.req2res.actionarybe.global.Timestamped;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Entity
 @Table(name = "todo_category")
 @Getter
@@ -25,6 +27,9 @@ public class TodoCategory extends Timestamped {
 
     @Column
     private String color;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;   // 이 날짜부터 카테고리가 보이기 시작(비즈니스 기준)
 
     //----메소드----
     public void updateName(String name) {

--- a/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoCategoryRepository.java
+++ b/src/main/java/com/req2res/actionarybe/domain/todo/repository/TodoCategoryRepository.java
@@ -3,6 +3,7 @@ package com.req2res.actionarybe.domain.todo.repository;
 import com.req2res.actionarybe.domain.todo.entity.TodoCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,9 +18,8 @@ public interface TodoCategoryRepository extends JpaRepository<TodoCategory, Long
     //유저 소유 + 존재 체크 메서드
     boolean existsByIdAndUserId(Long id, Long userId);
 
-    //특정 사용자로 최신순으로 카테고리 찾는 메소드
-    List<TodoCategory> findAllByUserIdOrderByCreatedAtAsc(Long userId);
-
+    //특정 사용자로 startDate 기준으로 카테고리 찾는 메소드
+    List<TodoCategory> findAllByUserIdAndStartDateLessThanEqualOrderByStartDateAsc(Long userId, LocalDate date);
 
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #192

## 📝작업 내용
- 투두 카테고리 생성 시 **비즈니스 기준 날짜(`startDate`)** 필드 추가
  - 프론트에서 선택한 날짜를 기준으로 카테고리가 유효하도록 설계
  - `createdAt`(서버 생성 시각)과 역할 분리
- 투두 카테고리 목록 조회 API를 **`startDate` 기준 조회 로직**으로 변경
  - `startDate <= 기준 날짜` 조건으로 카테고리 필터링
  - 기준 날짜는 query param(`date`)으로 전달, 미전달 시 오늘 날짜 기준
- 카테고리 생성/목록 조회 DTO에 `startDate` 필드 추가
- DB 마이그레이션
  - `todo_category` 테이블에 `start_date` 컬럼 추가
  - 기존 데이터는 `created_at` 날짜 기준으로 backfill 후 NOT NULL 처리
### 작업 결과 
<img width="459" height="236" alt="image" src="https://github.com/user-attachments/assets/17931662-26a2-467c-84f4-528e233ebe43" />
<img width="444" height="200" alt="image" src="https://github.com/user-attachments/assets/f4401c72-2864-4cea-8d31-ea47e9352bdb" />



## 💬리뷰 요구사항(선택)

