### PR TITLE
Fix/#198 signout

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
@@ -66,7 +66,7 @@ public class AuthService {
 
     // 탈퇴자면 nickname 대신 signoutName 돌려주는 메서드
     // 의도: nickname은 UNIQUE이고, signoutName은 아니므로, 모든 탈퇴자를 "(익명)" 하나로 처리할 수 있음
-    public String choosingNickname(Member member){
+    public String chooseNickname(Member member){
         return member.isWithdrawn()? "(익명)" : member.getNickname();
     }
 

--- a/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/auth/service/AuthService.java
@@ -45,12 +45,29 @@ public class AuthService {
             throw new CustomException(ErrorCode.WITHDRAWN_MEMBER);
         }
 
-        // 가시적 정보만 (익명)으로 바꿈.
-        member.setNickname("(익명)");
-        member.setName("(익명)");
+        //////// 탈퇴자 익명화 ////////
+        // 사용자와 관련된 정보는 모두 관련성 없는 정보로 채운다 (단, email, nickname, loginId는 UNIQUE이므로, 뒤에 id를 붙인다.)
+        // 또한, 만일 withdrawn이 참이라면, signoutName = "(알 수 없음)"으로 한 후, 이를 nickname 대신 내보낸다.
+        String uniqueKey = "_withdrawn_" + member.getId();
 
-        // 탈퇴했음 표시
         member.setWithdrawn(true);
+        member.setSignoutName("(익명)");
+
+        member.setLoginId("login" + uniqueKey);
+        member.setEmail("email" + uniqueKey + "@example.com");
+        member.setNickname("닉네임" + uniqueKey);
+
+        member.setName("탈퇴한 사용자");
+        member.setPhoneNumber("000-0000-0000");
+        member.setBirthday(LocalDate.of(1900, 1, 1));
+
+        member.setProfileImageUrl("https://actionary-s3-bucket-v2.s3.ap-northeast-2.amazonaws.com/static/default_profile/default_profile1.png");
+    }
+
+    // 탈퇴자면 nickname 대신 signoutName 돌려주는 메서드
+    // 의도: nickname은 UNIQUE이고, signoutName은 아니므로, 모든 탈퇴자를 "(익명)" 하나로 처리할 수 있음
+    public String choosingNickname(Member member){
+        return member.isWithdrawn()? "(익명)" : member.getNickname();
     }
 
     // 로그인

--- a/src/main/java/com/req2res/actionarybe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.req2res.actionarybe.domain.comment.service;
 
+import com.req2res.actionarybe.domain.auth.service.AuthService;
 import com.req2res.actionarybe.domain.comment.dto.*;
 import com.req2res.actionarybe.domain.comment.entity.Comment;
 import com.req2res.actionarybe.domain.comment.repository.CommentRepository;
@@ -26,6 +27,7 @@ public class CommentService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final NotificationService notificationService;
+    private final AuthService authService;
 
     // 댓글 생성
     @Transactional
@@ -89,7 +91,7 @@ public class CommentService {
                         comment.getIsSecret(),
                         new CommentInfoDTO.AuthorDTO(
                                 comment.getMember().getId(),
-                                comment.getMember().getNickname(),
+                                authService.chooseNickname(comment.getMember()),
                                 comment.getMember().getProfileImageUrl(),
                                 comment.getMember().getBadge().getId()
                         )

--- a/src/main/java/com/req2res/actionarybe/domain/member/entity/Member.java
+++ b/src/main/java/com/req2res/actionarybe/domain/member/entity/Member.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 )
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends Timestamped {
 
@@ -38,6 +39,9 @@ public class Member extends Timestamped {
 
     @Column(length=20)
     private String nickname;
+
+    @Column
+    private String signoutName;
 
     @Column(nullable=false)
     private LocalDate birthday;
@@ -74,6 +78,7 @@ public class Member extends Timestamped {
                 ? "https://actionary-s3-bucket-v2.s3.ap-northeast-2.amazonaws.com/static/default_profile/default_profile2.png" : profileImageUrl;
         this.nickname = (nickname == null || nickname.isBlank())
                 ? generateDefaultNickname() : nickname;
+        this.signoutName = nickname;
         this.badge = badge;
         this.withdrawn = false;
         // createdAt, updatedAt은 Timestamped에서 자동으로 위에 필드 변수에 넣어줄거라, 외부에서 주입받을 필요X
@@ -82,20 +87,4 @@ public class Member extends Timestamped {
     private String generateDefaultNickname() {
         return "user" + System.currentTimeMillis();
     }
-
-    public void setProfileImageUrl(String profileImageUrl) {
-        this.profileImageUrl = profileImageUrl;
-    }
-
-    public void setNickname(String nickname) {
-        this.nickname=nickname;
-    }
-
-    public void setName(String name) {this.name=name;}
-
-    public void setBadge(Badge badge) {
-        this.badge = badge;
-    }
-
-    public void setWithdrawn(boolean withdrawn) {this.withdrawn = withdrawn;}
 }

--- a/src/main/java/com/req2res/actionarybe/domain/member/service/MemberService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.req2res.actionarybe.domain.member.service;
 
+import com.req2res.actionarybe.domain.auth.service.AuthService;
 import com.req2res.actionarybe.domain.image.service.ImageService;
 import com.req2res.actionarybe.domain.member.dto.*;
 import com.req2res.actionarybe.domain.member.entity.Badge;
@@ -21,6 +22,7 @@ import java.util.Optional;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+    private final AuthService authService;
     private final ImageService imageService;
 
     public Member findMemberByLoginId(String loginId) {
@@ -32,10 +34,11 @@ public class MemberService {
     public LoginMemberResponseDTO getLoginMemberInfo(Long id) {
         Member member = memberRepository.findById(id)
                 .orElseThrow(()->new IllegalArgumentException("해당 회원이 없습니다."));
+
         return new LoginMemberResponseDTO(
                 member.getId(),
                 member.getProfileImageUrl(),
-                member.getNickname(),
+                authService.chooseNickname(member),
                 member.getPhoneNumber(),
                 member.getBirthday()
         );
@@ -45,9 +48,10 @@ public class MemberService {
     public OtherMemberResponseDTO getOtherMemberInfo(Long id) {
         Member member = memberRepository.findById(id)
                 .orElseThrow(()->new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
         return new OtherMemberResponseDTO(
                 member.getId(),
-                member.getNickname(),
+                authService.chooseNickname(member),
                 member.getProfileImageUrl()
         );
     }

--- a/src/main/java/com/req2res/actionarybe/domain/post/service/PostService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/service/PostService.java
@@ -135,9 +135,7 @@ public class PostService {
     public void delPostImages(List<String> delImages, Post post) {
         // 이미지 삭제
         for(String imageUrl : delImages){
-            System.out.println("@%#@"+isDelImageInS3(imageUrl)+"@%#@");
             if(isDelImageInS3(imageUrl)){
-                System.out.println("I'm in");
                 imageService.deleteImage(imageUrl);
                 post.removeImage(imageUrl);
             }else{

--- a/src/main/java/com/req2res/actionarybe/domain/post/service/PostService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.req2res.actionarybe.domain.post.service;
 
+import com.req2res.actionarybe.domain.auth.service.AuthService;
 import com.req2res.actionarybe.domain.image.service.ImageService;
 import com.req2res.actionarybe.domain.member.entity.Member;
 import com.req2res.actionarybe.domain.member.repository.MemberRepository;
@@ -28,6 +29,7 @@ public class PostService {
     private final PostImageRepository postImageRepository;
     private final MemberRepository memberRepository;
     private final ImageService imageService;
+    private final AuthService authService;
 
     // 게시글 생성
     @Transactional
@@ -90,7 +92,7 @@ public class PostService {
 
         PostAuthorDTO postAuthor = new PostAuthorDTO(
                 post.getMember().getId(),
-                post.getMember().getNickname(),
+                authService.chooseNickname(post.getMember()),
                 post.getMember().getProfileImageUrl(),
                 post.getMember().getBadge().getId()
         );
@@ -191,7 +193,7 @@ public class PostService {
                         post.getId(),
                         post.getType().name(),
                         post.getTitle(),
-                        post.getMember().getNickname(),
+                        authService.chooseNickname(post.getMember()),
                         post.getCommentsCount(),
                         post.getCreatedAt()
                 ))


### PR DESCRIPTION
## #️⃣연관된 이슈

closed (#198 )

## 📝작업 내용
**사용자 정보 익명화** **<- 바뀐 로직**
- loginId, email, nickname은 UNIQUE기에 member의 id를 이용해서 'UNIQUE에 위배되지 않는 탈퇴자 data' 만듦
```
String uniqueKey = "_withdrawn_" + this.id;

this.loginId = "login" + uniqueKey;
this.email = "email" + uniqueKey + "@example.com";
this.nickname = "닉네임" + uniqueKey;
```

- 나머지는 UNIQUE가 아니기에, 같은 data로 익명화 처리
```
this.name = "탈퇴한 사용자";
this.phoneNumber = "000-0000-0000";
this.birthday = LocalDate.of(1900, 1, 1);
this.profileImageUrl = "https://actionary-s3-bucket-v2.s3.ap-northeast-2.amazonaws.com/static/default_profile/default_profile1.png";
```

탈퇴시, 이런 식으로 UNIQUE 조건에 위배되지 않게 member의 정보가 바뀌게 됩니다.


**기존 로직**
1. withdraw 칼럼 추가 후, 회원탈퇴 시 true로 설정
2. nickname, name은 "(익명)"으로 변경

**수정 이유**
- 모든 회원탈퇴자의 nickname을 "(익명)"으로 하니까, UNIQUE 조건에 걸려서
- 거기에 회원 탈퇴 후, 사용자의 정보가 아직 남아있는게 심리적으로 걸려서

## 💬리뷰 요구사항(선택)
없음. (백엔드분들 허락 다 맡음)