### PR TITLE
fix: 스터디 검색 시 오류 해결

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/search/repository/SearchRepositoryImpl.java
+++ b/src/main/java/com/req2res/actionarybe/domain/search/repository/SearchRepositoryImpl.java
@@ -33,7 +33,14 @@ public class SearchRepositoryImpl implements SearchRepositoryCustom {
 
         // 정렬: POPULAR=즐겨찾기 수, RECENT=createdAt
         if (sort == SearchSort.POPULAR) {
-            cq.orderBy(cb.desc(study.get("bookmarkCount")), cb.desc(study.get("createdAt")));
+            // StudyLike join 후 개수로 정렬
+            Join<Study, ?> likes = study.join("studyLikes", JoinType.LEFT);
+
+            cq.groupBy(study.get("id")); // count 집계 때문에 필요
+            cq.orderBy(
+                    cb.desc(cb.count(likes.get("id"))),
+                    cb.desc(study.get("createdAt"))
+            );
         } else {
             cq.orderBy(cb.desc(study.get("createdAt")));
         }


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #205

## 📝작업 내용

- 스터디 검색 및 목록 조회 시 발생하던 서버 오류를 해결했습니다.
- `Study` 엔티티에 존재하지만 DB 테이블에 없던 컬럼(`long_description`)으로 인해 발생하던 SQL 오류를 수정했습니다.
- 엔티티-DB 스키마 불일치로 인한 `Unknown column` 오류를 DB 컬럼 추가로 해결했습니다.
- 검색/목록 조회 쿼리가 정상적으로 동작하도록 안정화했습니다.


## 💬리뷰 요구사항(선택)

