### PR TITLE
fix: 공부량 알림 텍스트 변경

### DIFF
--- a/src/main/java/com/req2res/actionarybe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/req2res/actionarybe/domain/notification/service/NotificationService.java
@@ -12,7 +12,6 @@ import com.req2res.actionarybe.domain.point.entity.PointSource;
 import com.req2res.actionarybe.global.exception.CustomException;
 import com.req2res.actionarybe.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -111,7 +110,7 @@ public class NotificationService {
         NotificationCreateRequestDTO req = NotificationCreateRequestDTO.of(
                 userId,
                 NotificationType.DAILY_STUDY_SUMMARY,
-                "오늘 공부량 리포트",
+                "어제 공부량 리포트",
                 summaryText,
                 null
         );


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #210

## 📝작업 내용

<img width="708" height="97" alt="image" src="https://github.com/user-attachments/assets/2faf748b-8f98-4d3b-9eb6-d7ef953a4c76" />


- 기존에 있던 ```오늘 공부량 리포트``` -> ```어제 공부량 리포트```로 텍스트 변경

## 💬리뷰 요구사항(선택)

